### PR TITLE
Check null for the init stmt inside a for stmt

### DIFF
--- a/oclint-rules/rules/naming/ShortVariableNameRule.cpp
+++ b/oclint-rules/rules/naming/ShortVariableNameRule.cpp
@@ -38,11 +38,16 @@ public:
 
     bool VisitForStmt(ForStmt *forStmt)
     {
-        DeclStmt *declStmt = dyn_cast<DeclStmt>(forStmt->getInit());
-        if (declStmt && declStmt->isSingleDecl())
+        Stmt *initStmt = forStmt->getInit();
+        if (initStmt)
         {
-            _suppressVarDecl = dyn_cast<VarDecl>(declStmt->getSingleDecl());
+            DeclStmt *declStmt = dyn_cast<DeclStmt>(initStmt);
+            if (declStmt && declStmt->isSingleDecl())
+            {
+                _suppressVarDecl = dyn_cast<VarDecl>(declStmt->getSingleDecl());
+            }
         }
+
         return true;
     }
 


### PR DESCRIPTION
This pull request should fix the crash due to a lack of null check inside `short variable name` rule found in issue #36.
