### PR TITLE
Ignore unused local variables without names

### DIFF
--- a/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
+++ b/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
@@ -30,6 +30,7 @@ public:
     bool VisitVarDecl(VarDecl *varDecl)
     {
         if (varDecl && !varDecl->isUsed() &&
+            varDecl->getNameAsString() != "" &&
             varDecl->isLocalVarDecl() &&
             !varDecl->isStaticDataMember() &&
             isInNonTemplateFunction(varDecl))

--- a/oclint-rules/test/unused/UnusedLocalVariableRuleTest.cpp
+++ b/oclint-rules/test/unused/UnusedLocalVariableRuleTest.cpp
@@ -45,6 +45,15 @@ TEST(UnusedLocalVariableRuleTest, IgnoreUnusedLocalVariableInTemplateFunction)
     testRuleOnCXXCode(new UnusedLocalVariableRule(), "template <typename T> int m() { int i = 1; return i; }");
 }
 
+/*
+ Tests for the false positive found by Reece Dunn
+ Details at https://github.com/oclint/oclint/issues/34
+*/
+TEST(UnusedLocalVariableRuleTest, IgnoreVariablesWithoutAName)
+{
+    testRuleOnCXXCode(new UnusedLocalVariableRule(), "void f(); bool g() { try { f(); } catch (int &) { return false; } return true; }");
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleMock(&argc, argv);


### PR DESCRIPTION
There are certain practices to leave an unused local variable without specifying a name, and this pull request will help `unused local variables` rule discard those cases. We also want to keep the `oclint` behavior consistent, since we ignore no-name-variables in `unused method parameter` rule, we should do the same thing here. Found in issue #34.
