### PR TITLE
Use all CPU cores to build clang

### DIFF
--- a/oclint-scripts/buildClang.sh
+++ b/oclint-scripts/buildClang.sh
@@ -24,9 +24,21 @@ fi
 mkdir -p $LLVM_BUILD
 cd $LLVM_BUILD
 
+if [ "$CPU_CORES" = "" ]; then
+    # Default to building on all cores, but allow single core builds using:
+    # "CPU_CORES=1 ./buildClang.sh release"
+    CPU_CORES=1
+    OS=$(uname -s)
+    if [ "$OS" = "Linux" ]; then
+        CPU_CORES=$(grep -c ^processor /proc/cpuinfo)
+    elif [ "$OS" = "Darwin" ]; then
+        CPU_CORES=$(sysctl -n hw.ncpu)
+    fi
+fi
+
 # configure and build
 cmake $RELEASE_CONFIG -D CMAKE_INSTALL_PREFIX=$LLVM_INSTALL $LLVM_SRC
-make
+make -j $CPU_CORES
 make install
 
 # back to the current folder


### PR DESCRIPTION
Fixes oclint github issue #38.

For my 8 core 2 year old machine I get the numbers below.

Time to build clang before this patch: 45m
Time to build clang after this patch: 11m
