### PR TITLE
Add suppress to unused local variable rule

### DIFF
--- a/oclint-rules/test/unused/UnusedLocalVariableRuleTest.cpp
+++ b/oclint-rules/test/unused/UnusedLocalVariableRuleTest.cpp
@@ -46,6 +46,65 @@ TEST(UnusedLocalVariableRuleTest, IgnoreUnusedLocalVariableInTemplateFunction)
 }
 
 /*
+ Resource Acquisition Is Initialization (RAII) programming idiom
+
+ TODO: this has been discussed in https://github.com/oclint/oclint/issues/32,
+ and it looks like we are not ready for having a whitelist for RAII yet,
+ so for now we added local suppress to unused local variable,
+ in case you use RAII idiom, you could suppress them.
+ */
+
+string stdMutexHeader = "\n\
+namespace std\n\
+{\n\
+class mutex\n\
+{\n\
+public:\n\
+     mutex();\n\
+};\n\
+struct adopt_lock_t {};\n\
+template <class Mutex>\n\
+class lock_guard\n\
+{\n\
+public:\n\
+    typedef Mutex mutex_type;\n\
+    explicit lock_guard(mutex_type& m);\n\
+    lock_guard(mutex_type& m, adopt_lock_t);\n\
+    ~lock_guard();\n\
+};\n\
+adopt_lock_t adopt_lock;\n\
+} // namespace std\n";
+
+TEST(UnusedLocalVariableRuleTest, IgnoreRAIITechniqueInWhitelist)
+{
+    testRuleOnCXXCode(new UnusedLocalVariableRule(), stdMutexHeader + "using namespace std; int m() { static mutex mtx; lock_guard<mutex> lock __attribute__((annotate(\"oclint:suppress\"))) (mtx); return 1; }");
+/*
+VarDecl 0x7f8fe18611d0 <input.cpp:21:50, col:76> lock 'lock_guard<class std::mutex>':'class std::lock_guard<class std::mutex>'
+`-CXXConstructExpr 0x7f8fe1863470 <col:68, col:76> 'lock_guard<class std::mutex>':'class std::lock_guard<class std::mutex>' 'void (mutex_type &)'
+  `-DeclRefExpr 0x7f8fe1861170 <col:73> 'class std::mutex' lvalue Var 0x7f8fe1860d60 'mtx' 'class std::mutex'
+ */
+}
+
+TEST(UnusedLocalVariableRuleTest, RAIITechniqueWhitelistDifferentNumOfParameters)
+{
+    testRuleOnCXXCode(new UnusedLocalVariableRule(), stdMutexHeader + "int m() { static std::mutex mutex; std::lock_guard<std::mutex> lock(mutex, std::adopt_lock); return 1; }",
+        0, 21, 36, 21, 91);
+/*
+VarDecl 0x7f8fe18610b0 <input.cpp:21:36, col:91> lock 'std::lock_guard<std::mutex>':'class std::lock_guard<class std::mutex>'
+`-CXXConstructExpr 0x7f8fe18635a0 <col:64, col:91> 'std::lock_guard<std::mutex>':'class std::lock_guard<class std::mutex>' 'void (mutex_type &, struct std::adopt_lock_t)'
+  |-DeclRefExpr 0x7f8fe1861048 <col:69> 'std::mutex':'class std::mutex' lvalue Var 0x7f8fe1860ba0 'mutex' 'std::mutex':'class std::mutex'
+  `-CXXConstructExpr 0x7f8fe1863418 <col:76, col:81> 'struct std::adopt_lock_t' 'void (const struct std::adopt_lock_t &) throw()'
+    `-ImplicitCastExpr 0x7f8fe18633b0 <col:76, col:81> 'const struct std::adopt_lock_t' lvalue <NoOp>
+      `-DeclRefExpr 0x7f8fe1861128 <col:76, col:81> 'struct std::adopt_lock_t' lvalue Var 0x7f8fe185fe60 'adopt_lock' 'struct std::adopt_lock_t'
+ */
+}
+
+TEST(UnusedLocalVariableRuleTest, SuppressUnusedLocalVariable)
+{
+    testRuleOnCode(new UnusedLocalVariableRule(), "void aMethod() { int a  __attribute__((annotate(\"oclint:suppress[unused local variable]\"))); }");
+}
+
+/*
  Tests for the false positive found by Reece Dunn
  Details at https://github.com/oclint/oclint/issues/34
 */


### PR DESCRIPTION
Looks like issue discussed in #32 is not ready for the coming release, so this quick solution is to add suppress support to `unused local variable` rule, so that RAII-style constructors can be suppressed based on users' judgment. 
