### PR TITLE
Fix the false positive for redundant nil check

### DIFF
--- a/oclint-rules/rules/redundant/RedundantNilCheckRule.cpp
+++ b/oclint-rules/rules/redundant/RedundantNilCheckRule.cpp
@@ -10,7 +10,16 @@ private:
 
     bool isRedundantNilCheck(BinaryOperator *binaryOperator)
     {
-        return binaryOperator->getOpcode() == BO_LAnd && isNeNullCheck(binaryOperator->getLHS());
+        if(binaryOperator->getOpcode() == BO_LAnd && isNeNullCheck(binaryOperator->getLHS()))
+        {
+            UnaryOperator *unaryOperator = dyn_cast<UnaryOperator>(binaryOperator->getRHS());
+            if (unaryOperator)
+            {
+                return unaryOperator->getOpcode() != UO_LNot;
+            }
+            return true;
+        }
+        return false;
     }
 
     bool hasVariableInExpr(string variableOfInterest, Expr *expr)

--- a/oclint-rules/test/redundant/RedundantNilCheckRuleTest.cpp
+++ b/oclint-rules/test/redundant/RedundantNilCheckRuleTest.cpp
@@ -52,6 +52,28 @@ TEST(RedundantNilCheckRuleTest, ObjC_ExplicitButRedundantNullEqCheck)
 @end", 0, 14, 9, 14, 44);
 }
 
+TEST(RedundantNilCheckRuleTest, ObjC_EzNullNeCheck)
+{
+    testRuleOnObjCCode(new RedundantNilCheckRule(), objcPrefix +
+"@implementation A\n\
+- (BOOL)isEqualTo:(id)obj { return YES; }                       \n\
++ (void)compare:(A *)obj1 withOther:(A *)obj2 {                 \n\
+    if (obj1 && ![obj1 isEqualTo:obj2]) { ; }                   \n\
+}                                                               \n\
+@end");
+}
+
+TEST(RedundantNilCheckRuleTest, ObjC_ExplicitNullNeCheck)
+{
+    testRuleOnObjCCode(new RedundantNilCheckRule(), objcPrefix +
+"@implementation A\n\
+- (BOOL)isEqualTo:(id)obj { return YES; }                       \n\
++ (void)compare:(A *)obj1 withOther:(A *)obj2 {                 \n\
+    if (obj1 != nil && ![obj1 isEqualTo:obj2]) { ; }            \n\
+}                                                               \n\
+@end");
+}
+
 TEST(RedundantNilCheckRuleTest, ObjC_LogicOrEzNullEqCheck)
 {
     testRuleOnObjCCode(new RedundantNilCheckRule(), objcPrefix +


### PR DESCRIPTION
The the right-hand side expression of the `logical and` binary operator is an unary operator, we need to make sure it's not a `logical not` unary operator.
