### PR TITLE
Fixed memory leak in Driver.cpp

### DIFF
--- a/oclint-driver/lib/Driver.cpp
+++ b/oclint-driver/lib/Driver.cpp
@@ -354,6 +354,8 @@ void Driver::run(const clang::tooling::CompilationDatabase &compilationDatabase,
         compilers.at(compilerIndex)->end();
         compilers.at(compilerIndex)->resetAndLeakFileManager();
         fileManagers.at(compilerIndex)->clearStatCaches();
+        delete compilers.at(compilerIndex);
+        delete fileManagers.at(compilerIndex);
     }
 
     if (option::enableClangChecker())


### PR DESCRIPTION
I was not able to use oclint on more than 20 files, because of a memory leak in Driver.cpp.

Maybe using auto_ptr<> or unique_ptr<> for the vector content would be the better solution.
