### PR TITLE
Ignore dependency commands

### DIFF
--- a/oclint-driver/lib/Driver.cpp
+++ b/oclint-driver/lib/Driver.cpp
@@ -48,7 +48,7 @@
 #include <unistd.h>
 
 #include <sstream>
-#include <iostream>
+
 #include <llvm/ADT/IntrusiveRefCntPtr.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Option/ArgList.h>


### PR DESCRIPTION
When creating the json compilation database using "bear make ..." and the makefile generates dependency files, there may be duplicate entries in the variable compileCommands in constructCompileCommands(), one entry for the dependency file generation, one entry for the actual compilation.

This patch filters the commands that contain "-M" or "-MM". The will be ignored.
