### PR TITLE
Added endcolumn and endline to pmd output.

### DIFF
--- a/oclint-reporters/reporters/PMDReporter.cpp
+++ b/oclint-reporters/reporters/PMDReporter.cpp
@@ -30,6 +30,7 @@ public:
 
     void writeHeader(std::ostream &out, std::string version)
     {
+        out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << std::endl;
         out << "<pmd version=\"oclint-" << version << "\">";
     }
 
@@ -43,7 +44,9 @@ public:
         out << "<file name=\"" << violation.path << "\">" << std::endl;
         out << "<violation ";
         out << "begincolumn=\"" << violation.startColumn << "\" ";
+        out << "endcolumn=\"" << violation.endColumn << "\" ";
         out << "beginline=\"" << violation.startLine << "\" ";
+        out << "endline=\"" << violation.endLine << "\" ";
         const RuleBase *rule = violation.rule;
         out << "priority=\"" << 2 * rule->priority() - 1 << "\" ";
         out << "rule=\"" << rule->name() << "\">" << std::endl;


### PR DESCRIPTION
With this patch jenkins (with pmd plugin) can mark the exact lines containing the issue.
Also added xml header to pmd output. But the encoding may be wrong.
