### PR TITLE
Make global analysis optional

### DIFF
--- a/oclint-core/include/oclint/RuleCarrier.h
+++ b/oclint-core/include/oclint/RuleCarrier.h
@@ -25,6 +25,7 @@ public:
     RuleCarrier(clang::ASTContext *astContext, ViolationSet *violationSet);
     clang::ASTContext* getASTContext();
     clang::SourceManager& getSourceManager();
+    std::string getMainFilePath();
     clang::TranslationUnitDecl* getTranslationUnitDecl();
 
     void addViolation(std::string filePath, int startLine, int startColumn,

--- a/oclint-core/lib/RuleCarrier.cpp
+++ b/oclint-core/lib/RuleCarrier.cpp
@@ -20,6 +20,13 @@ clang::SourceManager& RuleCarrier::getSourceManager()
     return getASTContext()->getSourceManager();
 }
 
+std::string RuleCarrier::getMainFilePath()
+{
+    clang::FileID mainFileId = getSourceManager().getMainFileID();
+    clang::SourceLocation mainSourceLocation = getSourceManager().getLocForStartOfFile(mainFileId);
+    return getSourceManager().getFilename(mainSourceLocation).str();
+}
+
 clang::TranslationUnitDecl* RuleCarrier::getTranslationUnitDecl()
 {
     return getASTContext()->getTranslationUnitDecl();

--- a/oclint-driver/include/oclint/Options.h
+++ b/oclint-driver/include/oclint/Options.h
@@ -22,6 +22,7 @@ namespace option
     int maxP2();
     int maxP3();
     bool showEnabledRules();
+    bool enableGlobalAnalysis();
     bool enableClangChecker();
 } // end namespace option
 } // end namespace oclint

--- a/oclint-driver/include/oclint/RulesetBasedAnalyzer.h
+++ b/oclint-driver/include/oclint/RulesetBasedAnalyzer.h
@@ -14,9 +14,7 @@ private:
 public:
     RulesetBasedAnalyzer(std::vector<RuleBase *> filteredRules);
 
-    virtual void preprocess(std::vector<clang::ASTContext *> &contexts);
     virtual void analyze(std::vector<clang::ASTContext *> &contexts);
-    virtual void postprocess(std::vector<clang::ASTContext *> &contexts);
 };
 
 } // end namespace oclint

--- a/oclint-driver/lib/Options.cpp
+++ b/oclint-driver/lib/Options.cpp
@@ -56,6 +56,10 @@ static llvm::cl::opt<int> argMaxP3("max-priority-3",
     llvm::cl::desc("The max allowed number of priority 3 violations"),
     llvm::cl::value_desc("threshold"),
     llvm::cl::init(20));
+static llvm::cl::opt<bool> argGlobalAnalysis("enable-global-analysis",
+    llvm::cl::desc("Compile every source, and analyze across global contexts "
+        "(depends on number of source files, could results in high memory load)"),
+    llvm::cl::init(false));
 static llvm::cl::opt<bool> argClangChecker("enable-clang-static-analyzer",
     llvm::cl::desc("Enable Clang Static Analyzer, and integrate results into OCLint report"),
     llvm::cl::init(false));
@@ -138,6 +142,11 @@ int oclint::option::maxP3()
 bool oclint::option::showEnabledRules()
 {
     return argListEnabledRules;
+}
+
+bool oclint::option::enableGlobalAnalysis()
+{
+    return argGlobalAnalysis;
 }
 
 bool oclint::option::enableClangChecker()

--- a/oclint-driver/lib/RulesetBasedAnalyzer.cpp
+++ b/oclint-driver/lib/RulesetBasedAnalyzer.cpp
@@ -13,41 +13,20 @@ RulesetBasedAnalyzer::RulesetBasedAnalyzer(std::vector<RuleBase *> filteredRules
 {
 }
 
-void RulesetBasedAnalyzer::preprocess(std::vector<clang::ASTContext *> &contexts)
-{
-    debug::emit("Start pre-processing:\n");
-    for (const auto& context : contexts)
-    {
-        debug::emit(".");
-    }
-    debug::emit("\n");
-}
-
 void RulesetBasedAnalyzer::analyze(std::vector<clang::ASTContext *> &contexts)
 {
-    debug::emit("Start analyzing:\n");
     for (const auto& context : contexts)
     {
-        debug::emit(".");
+        debug::emit("Analyzing ");
         ViolationSet *violationSet = new ViolationSet();
         RuleCarrier *carrier = new RuleCarrier(context, violationSet);
+        debug::emit(carrier->getMainFilePath().c_str());
         for (RuleBase *rule : _filteredRules)
         {
             rule->takeoff(carrier);
         }
         Results *results = Results::getInstance();
         results->add(violationSet);
-
+        debug::emit(" - Done\n");
     }
-    debug::emit("\n");
-}
-
-void RulesetBasedAnalyzer::postprocess(std::vector<clang::ASTContext *> &contexts)
-{
-    debug::emit("Start post-processing:\n");
-    for (const auto& context : contexts)
-    {
-        debug::emit(".");
-    }
-    debug::emit("\n");
 }


### PR DESCRIPTION
We have noticed the high memory usage in #75, and we would like to revert back to single AST mode by default, and enable global analysis only by users' intents.
