### PR TITLE
Enable LLVM Runtime for Mac and Linux Builds

### DIFF
--- a/oclint-scripts/clang
+++ b/oclint-scripts/clang
@@ -34,7 +34,9 @@ def build_command(is_release):
     else:
         cmd_build.append('CMAKE_BUILD_TYPE', 'Debug')
     if environment.is_mingw32():
-        cmd_build.append('LLVM_EXTERNAL_COMPILER_RT_BUILD:BOOL', 'OFF')
+        cmd_build.append('LLVM_BUILD_RUNTIME', 'OFF')
+    else:
+        cmd_build.append('LLVM_BUILD_RUNTIME', 'ON')
     if environment.is_darwin() and not environment.is_darwin_13():
         cmd_build.append('CMAKE_CXX_FLAGS', '-std=c++11 -stdlib=libc++ ${CMAKE_CXX_FLAGS}', True)
     cmd_build.append('CMAKE_INSTALL_PREFIX', path.build.clang_install_dir, environment.is_mingw32())


### PR DESCRIPTION
According to LLVM's recent changes, https://github.com/llvm-mirror/llvm/commit/dd5d86d992eb129ecd0bb013d2db2d6a0e8d2605, building runtime libraries are disabled by default. However we need compiler-rt for Mac and Linux builds, so we turn the flag on explicitly.
