### PR TITLE
Remove extra comma in CMakeLists for cocoa preventing rules from building

### DIFF
--- a/oclint-rules/rules/cocoa/CMakeLists.txt
+++ b/oclint-rules/rules/cocoa/CMakeLists.txt
@@ -1,4 +1,4 @@
-SET(LIST_OF_RULES,
+SET(LIST_OF_RULES
     ObjCVerifyMustCallSuper
     )
 


### PR DESCRIPTION
Whoops
