### PR TITLE
Remove library cases from must call super rule.

### DIFF
--- a/oclint-rules/rules/cocoa/ObjCVerifyMustCallSuperRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyMustCallSuperRule.cpp
@@ -42,28 +42,7 @@ class ObjCVerifyMustCallSuperRule : public AbstractASTVisitorRule<ObjCVerifyMust
 private:
     static RuleSet rules;
 
-    map<string, vector<string>> _libraryCases;
-
-    bool isLibraryCase(const ObjCMethodDecl* decl) {
-        string selectorName = decl->getSelector().getAsString();
-        auto classNames = _libraryCases.find(selectorName);
-        if(classNames != _libraryCases.end()) {
-            auto classes = classNames->second;
-            for(auto it = classes.begin(), ite = classes.end(); it != ite; ++it) {
-                if(isObjCMethodDeclInChildOfClass(decl, *it)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
     bool declRequiresSuperCall(ObjCMethodDecl* decl) {
-        if(isLibraryCase(decl)) {
-            return true;
-        }
-
         if(decl->isOverriding()) {
             SmallVector<const ObjCMethodDecl*, 4> overridden;
             decl->getOverriddenMethods(overridden);
@@ -80,27 +59,6 @@ private:
 
 public:
     
-    ObjCVerifyMustCallSuperRule() {
-        // UIKit cases
-        _libraryCases["viewWillAppear:"] = {"UIViewController"};
-        _libraryCases["viewDidAppear:"] = {"UIViewController"};
-        _libraryCases["viewWillDisappear:"] = {"UIViewController"};
-        _libraryCases["viewDidDisappear:"] = {"UIViewController"};
-        _libraryCases["viewDidLayoutSubviews"] = {"UIViewController"};
-        _libraryCases["layoutSubviews"] = {"UIView"};
-        _libraryCases["updateConstraints"] = {"UIView"};
-        _libraryCases["viewDidLoad"] = {"UIView"};
-        _libraryCases["reset"] = {"UIGestureRecognizer"};
-        _libraryCases["canPreventGestureRecognizer:"] = {"UIGestureRecognizer"};
-        _libraryCases["canBePreventedByGestureRecognizer:"] = {"UIGestureRecognizer"};
-        _libraryCases["shouldRequireFailureOfGestureRecognizer:"] = {"UIGestureRecognizer"};
-        _libraryCases["shouldBeRequiredToFailByGestureRecognizer:"] = {"UIGestureRecognizer"};
-        _libraryCases["touchesBegan:withEvent:"] = {"UIGestureRecognizer"};
-        _libraryCases["touchesMoved:withEvent:"] = {"UIGestureRecognizer"};
-        _libraryCases["touchesEnded:withEvent:"] = {"UIViewController"};
-        _libraryCases["touchesCancelled:withEvent:"] = {"UIGestureRecognizer"};
-    }
-
     virtual const string name() const
     {
         return "must call super";

--- a/oclint-rules/test/cocoa/ObjCVerifyMustCallSuperRuleTest.cpp
+++ b/oclint-rules/test/cocoa/ObjCVerifyMustCallSuperRuleTest.cpp
@@ -24,23 +24,6 @@ static string testDoesNotCall = "\
                                                     \n\
 ";
 
-static string testLibraryBase = "\
-typedef unsigned char BOOL;                         \n\
-                                                    \n\
-@interface UIViewController                         \n\
-                                                    \n\
-- (void)viewWillAppear:(BOOL)animated;              \n\
-                                                    \n\
-@end                                                \n\
-                                                    \n\
-                                                    \n\
-@interface ChildViewController : UIViewController   \n\
-                                                    \n\
-@end                                                \n\
-";
-
-static string testLibraryDoesCall = testLibraryBase + testDoesCall;
-static string testLibraryDoesNotCall = testLibraryBase + testDoesNotCall;
 
 static string testAnnotationBase = "\
 typedef unsigned char BOOL;                                                                    \n\
@@ -76,7 +59,6 @@ static string testSuppression = "\
 
 
 static string testAnnotationSuppression = testAnnotationBase + testSuppression;
-static string testLibrarySuppression = testLibraryBase + testSuppression;
 
 static string testNormalMethod = "\
 @interface NSObject                                 \n\
@@ -114,18 +96,6 @@ TEST(ObjcVerifyMustCallSuperRuleTest, PropertyTest)
     EXPECT_EQ("must call super", rule.name());
 }
 
-TEST(ObjcVerifyMustCallSuperRuleTest, LibraryDoesCall)
-{
-    testRuleOnObjCCode(new ObjCVerifyMustCallSuperRule(), testLibraryDoesCall);
-}
-
-TEST(ObjcVerifyMustCallSuperRuleTest, LibraryDoesNotCall)
-{
-    testRuleOnObjCCode(new ObjCVerifyMustCallSuperRule(),
-        testLibraryDoesNotCall, 0, 16, 1, 17, 1,
-        "overridden method viewWillAppear: must call super");
-}
-
 TEST(ObjcVerifyMustCallSuperRuleTest, AnnotationDoesCall)
 {
     testRuleOnObjCCode(new ObjCVerifyMustCallSuperRule(), testAnnotationDoesCall);
@@ -136,11 +106,6 @@ TEST(ObjcVerifyMustCallSuperRuleTest, AnnotationDoesNotCall)
     testRuleOnObjCCode(new ObjCVerifyMustCallSuperRule(),
         testAnnotationDoesNotCall, 0, 19, 1, 20, 1,
         "overridden method viewWillAppear: must call super");
-}
-
-TEST(ObjcVerifyMustCallSuperRuleTest, LibrarySuppression)
-{
-    testRuleOnObjCCode(new ObjCVerifyMustCallSuperRule(), testLibrarySuppression);
 }
 
 TEST(ObjcVerifyMustCallSuperRuleTest, AnnotationSuppression)


### PR DESCRIPTION
I figured out that I could use objc categories to annotate existing library methods, so we don't need to hard code them into the rule after all. We didn't _need_ to get rid of them here, but it seems like good hygiene.
