### PR TITLE
Fix false positive of `const int k = 42; foo(k);` with C++11.

### DIFF
--- a/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
+++ b/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
@@ -28,7 +28,7 @@ private:
 
     bool isUnused(VarDecl *varDecl)
     {
-        return !varDecl->isUsed();
+        return !varDecl->isUsed() && !varDecl.isReferenced();
     }
 
     bool hasName(VarDecl *varDecl)

--- a/oclint-rules/test/unused/UnusedLocalVariableRuleTest.cpp
+++ b/oclint-rules/test/unused/UnusedLocalVariableRuleTest.cpp
@@ -26,6 +26,12 @@ TEST(UnusedLocalVariableRuleTest, UnusedLocalVariableWithIntialAssignment)
         0, 1, 18, 1, 26, "The local variable 'a' is unused.");
 }
 
+TEST(UnusedLocalVariableRuleTest, UsedConstLocalVariable)
+{
+    testRuleOnCXX11Code(new UnusedLocalVariableRule(),
+        "void f(int dummy) { const int a = 1; f(a);}");
+}
+
 TEST(UnusedLocalVariableRuleTest, DeclarationOutsideMethodShouldBeIgnored)
 {
     testRuleOnCode(new UnusedLocalVariableRule(), "int i = 1;");


### PR DESCRIPTION
Strange that `const int k = 42; foo(k);` was corrected detected in C but not in C++11.
