### PR TITLE
Enable building and bundling with an external llvm/clang build

### DIFF
--- a/oclint-scripts/build
+++ b/oclint-scripts/build
@@ -18,23 +18,24 @@ arg_parser.add_argument('module_name', nargs='?', choices=['all'] + OCLINT_MODUL
 arg_parser.add_argument('-release', '--release', action="store_true")
 arg_parser.add_argument('-clean', '--clean', action="store_true")
 arg_parser.add_argument('-j', type=int, default=0)
+arg_parser.add_argument('-llvm-root', '--llvm-root', default=path.build.clang_install_dir)
 args = arg_parser.parse_args()
 
 def clean_module(module_name):
     build_path = path.oclint_module_build_dir(module_name)
     path.rm_f(build_path)
 
-def build_command(is_release, module_extras, source_path):
+def build_command(llvm_root, is_release, module_extras, source_path):
     cmd_build = cmake.builder(source_path)
     if is_release:
         cmd_build.release_build()
     if environment.is_unix():
         cmd_build.use_clang_compiler()
-    extras = {'LLVM_ROOT': path.build.clang_install_dir}
+    extras = {'LLVM_ROOT': llvm_root}
     extras.update(module_extras)
     return cmd_build.append_dict(extras).str()
 
-def build_module(module_name, is_release, multiple_thread):
+def build_module(module_name, llvm_root, is_release, multiple_thread):
     build_path = path.oclint_module_build_dir(module_name)
     source_path = path.oclint_module_source_dir(module_name)
 
@@ -46,7 +47,7 @@ def build_module(module_name, is_release, multiple_thread):
         module_extras['OCLINT_METRICS_SOURCE_DIR'] = path.source.metrics_dir
         module_extras['OCLINT_METRICS_BUILD_DIR'] = path.build.metrics_build_dir
 
-    command = build_command(is_release, module_extras, source_path)
+    command = build_command(llvm_root, is_release, module_extras, source_path)
 
     current_dir = os.getcwd()
     path.mkdir_p(build_path)
@@ -72,4 +73,4 @@ if not args.j is 0:
     multiple_thread = args.j
 
 for module in build_modules:
-    build_module(module, args.release, str(multiple_thread))
+    build_module(module, args.llvm_root, args.release, str(multiple_thread))

--- a/oclint-scripts/bundle
+++ b/oclint-scripts/bundle
@@ -19,6 +19,7 @@ bundle_lib_oclint_dir = os.path.join(bundle_lib_dir, 'oclint')
 arg_parser = argparse.ArgumentParser()
 arg_parser.add_argument('-archive', '--archive', action='store_true')
 arg_parser.add_argument('-release', '--release', action='store_true')
+arg_parser.add_argument('-llvm-root', '--llvm-root', default=path.build.clang_install_dir)
 args = arg_parser.parse_args()
 
 def clean_module(module_name):
@@ -65,8 +66,8 @@ def install_reporters():
     reporters_dst_path = os.path.join(bundle_lib_oclint_dir, 'reporters')
     path.cp_r(reporters_src_path, reporters_dst_path)
 
-def install_clang_headers():
-    clang_headers_src_path = os.path.join(path.build.clang_install_dir, 'lib', 'clang')
+def install_clang_headers(llvm_root):
+    clang_headers_src_path = os.path.join(llvm_root, 'lib', 'clang')
     clang_headers_dst_path = os.path.join(bundle_lib_dir, 'clang')
     path.cp_r(clang_headers_src_path, clang_headers_dst_path)
 
@@ -115,7 +116,7 @@ install_licenses()
 install_binary()
 install_rules()
 install_reporters()
-install_clang_headers()
+install_clang_headers(args.llvm_root)
 install_json_compilation_database()
 install_xcodebuild()
 

--- a/oclint-scripts/makeWithExternClang
+++ b/oclint-scripts/makeWithExternClang
@@ -1,0 +1,4 @@
+#! /bin/sh -e
+
+./build -llvm-root=$1 -release -clean
+./bundle -llvm-root=$1 -release -clean


### PR DESCRIPTION
This tries to compile oclint with an external llvm/clang build by specifying the path to an existing llvm install.

Reference: #93, #12
