### PR TITLE
Migrating to C++11 - run clang-modernize.

### DIFF
--- a/oclint-core/include/oclint/RuleConfiguration.h
+++ b/oclint-core/include/oclint/RuleConfiguration.h
@@ -2,16 +2,12 @@
 #define OCLINT_RULECONFIGURATION_H
 
 #include <string>
-#include <map>
 
 namespace oclint
 {
 
 class RuleConfiguration
 {
-private:
-    static std::map<std::string, std::string>* _configurations;
-
 public:
     static void addConfiguration(std::string key, std::string value);
     static bool hasKey(std::string key);

--- a/oclint-core/include/oclint/RuleSet.h
+++ b/oclint-core/include/oclint/RuleSet.h
@@ -1,8 +1,6 @@
 #ifndef OCLINT_RULESET_H
 #define OCLINT_RULESET_H
 
-#include <vector>
-
 namespace oclint
 {
 
@@ -10,11 +8,8 @@ class RuleBase;
 
 class RuleSet
 {
-private:
-    static std::vector<RuleBase*>* _rules;
-
 public:
-    RuleSet(RuleBase* rule);
+    explicit RuleSet(RuleBase* rule);
     static int numberOfRules();
     static RuleBase* getRuleAtIndex(int index);
 };

--- a/oclint-core/include/oclint/Violation.h
+++ b/oclint-core/include/oclint/Violation.h
@@ -19,13 +19,10 @@ public:
     int endColumn;
     std::string message;
 
-    Violation(RuleBase *violatedRule,
-        const std::string& violationFilePath,
-        int violationStartLine,
-        int violationStartColumn,
-        int violationEndLine,
-        int violationEndColumn,
-        const std::string& violationMessage = "");
+    Violation(RuleBase* violatedRule, std::string violationFilePath,
+              int violationStartLine, int violationStartColumn,
+              int violationEndLine, int violationEndColumn,
+              std::string violationMessage = "");
 };
 
 } // end namespace oclint

--- a/oclint-core/lib/Results.cpp
+++ b/oclint-core/lib/Results.cpp
@@ -5,11 +5,11 @@
 
 using namespace oclint;
 
-Results* Results::_singleton = NULL;
+Results* Results::_singleton = nullptr;
 
 Results* Results::getInstance()
 {
-    if (_singleton == NULL)
+    if (_singleton == nullptr)
     {
         _singleton = new Results();
     }
@@ -26,11 +26,11 @@ Results::Results()
 Results::~Results()
 {
     delete _compilerErrorSet;
-    _compilerErrorSet = NULL;
+    _compilerErrorSet = nullptr;
     delete _compilerWarningSet;
-    _compilerWarningSet = NULL;
+    _compilerWarningSet = nullptr;
     delete _clangStaticCheckerBugSet;
-    _clangStaticCheckerBugSet = NULL;
+    _clangStaticCheckerBugSet = nullptr;
 }
 
 void Results::add(ViolationSet *violationSet)

--- a/oclint-core/lib/RuleConfiguration.cpp
+++ b/oclint-core/lib/RuleConfiguration.cpp
@@ -1,14 +1,15 @@
-#include <cstdlib>
-
 #include "oclint/RuleConfiguration.h"
+
+#include <cstdlib>
+#include <map>
 
 using namespace oclint;
 
-std::map<std::string, std::string>* RuleConfiguration::_configurations = NULL;
+static std::map<std::string, std::string>* _configurations = nullptr;
 
 void RuleConfiguration::addConfiguration(std::string key, std::string value)
 {
-    if (_configurations == NULL)
+    if (_configurations == nullptr)
     {
         _configurations = new std::map<std::string, std::string>();
     }
@@ -18,7 +19,8 @@ void RuleConfiguration::addConfiguration(std::string key, std::string value)
 
 bool RuleConfiguration::hasKey(std::string key)
 {
-    return _configurations != NULL && _configurations->find(key) != _configurations->end();
+    return _configurations != nullptr &&
+           _configurations->find(key) != _configurations->end();
 }
 
 std::string RuleConfiguration::valueForKey(std::string key)
@@ -28,9 +30,9 @@ std::string RuleConfiguration::valueForKey(std::string key)
 
 void RuleConfiguration::removeAll()
 {
-    if (_configurations != NULL)
+    if (_configurations != nullptr)
     {
-        _configurations = NULL;
+        _configurations = nullptr;
     }
 }
 

--- a/oclint-core/lib/RuleSet.cpp
+++ b/oclint-core/lib/RuleSet.cpp
@@ -1,13 +1,15 @@
-#include "oclint/RuleBase.h"
 #include "oclint/RuleSet.h"
+#include "oclint/RuleBase.h"
+
+#include <vector>
 
 using namespace oclint;
 
-std::vector<RuleBase*>* RuleSet::_rules = NULL;
+static std::vector<RuleBase*>* _rules = nullptr;
 
 RuleSet::RuleSet(RuleBase* rule)
 {
-    if (_rules == NULL)
+    if (_rules == nullptr)
     {
         _rules = new std::vector<RuleBase*>();
     }
@@ -16,14 +18,14 @@ RuleSet::RuleSet(RuleBase* rule)
 
 int RuleSet::numberOfRules()
 {
-    return _rules == NULL ? 0 : _rules->size();
+    return _rules == nullptr ? 0 : _rules->size();
 }
 
 RuleBase* RuleSet::getRuleAtIndex(int index)
 {
     if (index >= numberOfRules())
     {
-        return NULL; // Better throwing an exception
+        return nullptr; // Better throwing an exception
     }
     return _rules->at(index);
 }

--- a/oclint-core/lib/Violation.cpp
+++ b/oclint-core/lib/Violation.cpp
@@ -1,16 +1,14 @@
 #include "oclint/RuleBase.h"
 #include "oclint/Violation.h"
+#include <utility>
 
 using namespace oclint;
 
-Violation::Violation(RuleBase *violatedRule,
-    const std::string& violationFilePath,
-    int violationStartLine,
-    int violationStartColumn,
-    int violationEndLine,
-    int violationEndColumn,
-    const std::string& violationMessage)
-    : path(violationFilePath), message(violationMessage)
+Violation::Violation(RuleBase* violatedRule, std::string violationFilePath,
+                     int violationStartLine, int violationStartColumn,
+                     int violationEndLine, int violationEndColumn,
+                     std::string violationMessage)
+    : path(std::move(violationFilePath)), message(std::move(violationMessage))
 {
     rule = violatedRule;
     startLine = violationStartLine;

--- a/oclint-driver/include/oclint/DiagnosticDispatcher.h
+++ b/oclint-driver/include/oclint/DiagnosticDispatcher.h
@@ -12,9 +12,9 @@ private:
     bool _isCheckerCustomer;
 
 public:
-    DiagnosticDispatcher(bool runClangChecker);
+    explicit DiagnosticDispatcher(bool runClangChecker);
     void HandleDiagnostic(clang::DiagnosticsEngine::Level diagnosticLevel,
-        const clang::Diagnostic &diagnosticInfo);
+                          const clang::Diagnostic& diagnosticInfo) override;
 };
 
 } // end namespace oclint

--- a/oclint-driver/include/oclint/GenericException.h
+++ b/oclint-driver/include/oclint/GenericException.h
@@ -10,9 +10,9 @@ namespace oclint
 class GenericException : public std::exception
 {
 public:
-    GenericException(const std::string& desc);
+    explicit GenericException(std::string desc);
     virtual ~GenericException() throw() {}
-    virtual const char *what() const throw();
+    virtual const char* what() const throw() override;
 
 private:
     std::string description;

--- a/oclint-driver/include/oclint/RulesetBasedAnalyzer.h
+++ b/oclint-driver/include/oclint/RulesetBasedAnalyzer.h
@@ -12,9 +12,9 @@ private:
     std::vector<RuleBase *> _filteredRules;
 
 public:
-    RulesetBasedAnalyzer(std::vector<RuleBase *> filteredRules);
+    explicit RulesetBasedAnalyzer(std::vector<RuleBase *> filteredRules);
 
-    virtual void analyze(std::vector<clang::ASTContext *> &contexts);
+    virtual void analyze(std::vector<clang::ASTContext*>& contexts) override;
 };
 
 } // end namespace oclint

--- a/oclint-driver/lib/DiagnosticDispatcher.cpp
+++ b/oclint-driver/lib/DiagnosticDispatcher.cpp
@@ -29,7 +29,8 @@ void DiagnosticDispatcher::HandleDiagnostic(clang::DiagnosticsEngine::Level diag
     clang::SmallString<100> diagnosticMessage;
     diagnosticInfo.FormatDiagnostic(diagnosticMessage);
 
-    Violation violation(0, filename.str(), line, column, 0, 0, diagnosticMessage.str().str());
+    Violation violation(nullptr, filename.str(), line, column, 0, 0,
+                        diagnosticMessage.str().str());
 
     Results *results = Results::getInstance();
     if (_isCheckerCustomer)

--- a/oclint-driver/lib/Driver.cpp
+++ b/oclint-driver/lib/Driver.cpp
@@ -118,7 +118,7 @@ static clang::CompilerInvocation *newInvocation(clang::DiagnosticsEngine *diagno
     const llvm::opt::ArgStringList &argStringList)
 {
     assert(!argStringList.empty() && "Must at least contain the program name!");
-    clang::CompilerInvocation *invocation = new clang::CompilerInvocation;
+    auto invocation = new clang::CompilerInvocation;
     clang::CompilerInvocation::CreateFromArgs(*invocation,
         argStringList.data() + 1, argStringList.data() + argStringList.size(), *diagnostics);
     invocation->getFrontendOpts().DisableFree = false;
@@ -212,7 +212,7 @@ static clang::FileManager *newFileManager()
 static oclint::CompilerInstance *newCompilerInstance(clang::CompilerInvocation *compilerInvocation,
     clang::FileManager *fileManager, bool runClangChecker = false)
 {
-    oclint::CompilerInstance *compilerInstance = new oclint::CompilerInstance();
+    auto compilerInstance = new oclint::CompilerInstance();
     compilerInstance->setInvocation(compilerInvocation);
     compilerInstance->setFileManager(fileManager);
     compilerInstance->createDiagnostics(new DiagnosticDispatcher(runClangChecker));

--- a/oclint-driver/lib/GenericException.cpp
+++ b/oclint-driver/lib/GenericException.cpp
@@ -1,8 +1,10 @@
 #include "oclint/GenericException.h"
+#include <utility>
 
 using namespace oclint;
 
-GenericException::GenericException(const std::string& desc) : description(desc)
+GenericException::GenericException(std::string desc)
+    : description(std::move(desc))
 {
 }
 

--- a/oclint-driver/lib/RulesetBasedAnalyzer.cpp
+++ b/oclint-driver/lib/RulesetBasedAnalyzer.cpp
@@ -5,11 +5,12 @@
 #include "oclint/RuleSet.h"
 #include "oclint/RulesetBasedAnalyzer.h"
 #include "oclint/ViolationSet.h"
+#include <utility>
 
 using namespace oclint;
 
-RulesetBasedAnalyzer::RulesetBasedAnalyzer(std::vector<RuleBase *> filteredRules)
-    : _filteredRules(filteredRules)
+RulesetBasedAnalyzer::RulesetBasedAnalyzer(std::vector<RuleBase*> filteredRules)
+    : _filteredRules(std::move(filteredRules))
 {
 }
 
@@ -18,8 +19,8 @@ void RulesetBasedAnalyzer::analyze(std::vector<clang::ASTContext *> &contexts)
     for (const auto& context : contexts)
     {
         debug::emit("Analyzing ");
-        ViolationSet *violationSet = new ViolationSet();
-        RuleCarrier *carrier = new RuleCarrier(context, violationSet);
+        auto violationSet = new ViolationSet();
+        auto carrier = new RuleCarrier(context, violationSet);
         debug::emit(carrier->getMainFilePath().c_str());
         for (RuleBase *rule : _filteredRules)
         {

--- a/oclint-driver/main.cpp
+++ b/oclint-driver/main.cpp
@@ -50,7 +50,7 @@ ostream* outStream()
         return &cout;
     }
     string output = oclint::option::outputPath();
-    ofstream *out = new ofstream(output.c_str());
+    auto out = new ofstream(output.c_str());
     if (!out->is_open())
     {
         throw oclint::GenericException("cannot open report output file " + output);

--- a/oclint-driver/reporters_dlfcn_port.cpp
+++ b/oclint-driver/reporters_dlfcn_port.cpp
@@ -7,14 +7,14 @@
 
 #include "reporters.h"
 
-static oclint::Reporter *selectedReporter = NULL;
+static oclint::Reporter* selectedReporter = nullptr;
 
 void loadReporter()
 {
-    selectedReporter = NULL;
+    selectedReporter = nullptr;
     std::string reportDirPath = oclint::option::reporterPath();
     DIR *pDir = opendir(reportDirPath.c_str());
-    if (pDir != NULL)
+    if (pDir != nullptr)
     {
         struct dirent *dirp;
         while ((dirp = readdir(pDir)))
@@ -25,7 +25,7 @@ void loadReporter()
             }
             std::string reporterPath = reportDirPath + "/" + std::string(dirp->d_name);
             void *reporterHandle = dlopen(reporterPath.c_str(), RTLD_LAZY);
-            if (reporterHandle == NULL)
+            if (reporterHandle == nullptr)
             {
                 std::cerr << dlerror() << std::endl;
                 closedir(pDir);
@@ -42,7 +42,7 @@ void loadReporter()
         }
         closedir(pDir);
     }
-    if (selectedReporter == NULL)
+    if (selectedReporter == nullptr)
     {
         throw oclint::GenericException(
             "cannot find dynamic library for report type: " + oclint::option::reportType());

--- a/oclint-driver/rules_dlfcn_port.cpp
+++ b/oclint-driver/rules_dlfcn_port.cpp
@@ -9,7 +9,7 @@
 void dynamicLoadRules(std::string ruleDirPath)
 {
     DIR *pDir = opendir(ruleDirPath.c_str());
-    if (pDir != NULL)
+    if (pDir != nullptr)
     {
         struct dirent *dirp;
         while ((dirp = readdir(pDir)))
@@ -19,7 +19,7 @@ void dynamicLoadRules(std::string ruleDirPath)
                 continue;
             }
             std::string rulePath = ruleDirPath + "/" + std::string(dirp->d_name);
-            if (dlopen(rulePath.c_str(), RTLD_LAZY) == NULL)
+            if (dlopen(rulePath.c_str(), RTLD_LAZY) == nullptr)
             {
                 std::cerr << dlerror() << std::endl;
                 closedir(pDir);

--- a/oclint-reporters/reporters/HTMLReporter.cpp
+++ b/oclint-reporters/reporters/HTMLReporter.cpp
@@ -10,12 +10,12 @@ using namespace oclint;
 class HTMLReporter : public Reporter
 {
 public:
-    virtual const std::string name() const
+    virtual const std::string name() const override
     {
         return "html";
     }
 
-    virtual void report(Results *results, std::ostream &out)
+    virtual void report(Results* results, std::ostream& out) override
     {
         out << "<!DOCTYPE html>";
         out << "<html>";
@@ -54,7 +54,7 @@ public:
 
     void writeFooter(std::ostream &out, std::string version)
     {
-        time_t now = time(0);
+        time_t now = time(nullptr);
         out << "<p>" << ctime(&now)
             << "| Generated with <a href='http://oclint.org'>OCLint v" << version << "</a>.</p>";
     }
@@ -88,9 +88,8 @@ public:
 
     void writeCheckerBugs(std::ostream &out, std::vector<Violation> violations)
     {
-        for (int index = 0, total = violations.size(); index < total; index++)
+        for (const auto& violation : violations)
         {
-            Violation violation = violations.at(index);
             out << "<tr><td>" << violation.path << "</td><td>" << violation.startLine
                 << ":" << violation.startColumn << "</td>";
             out << "<td>clang static analyzer</td><td class='checker-bug'>"

--- a/oclint-reporters/reporters/JSONReporter.cpp
+++ b/oclint-reporters/reporters/JSONReporter.cpp
@@ -10,12 +10,12 @@ using namespace oclint;
 class JSONReporter : public Reporter
 {
 public:
-    virtual const std::string name() const
+    virtual const std::string name() const override
     {
         return "json";
     }
 
-    virtual void report(Results *results, std::ostream &out)
+    virtual void report(Results* results, std::ostream& out) override
     {
         out << "{";
         writeHeader(out, Version::identifier());
@@ -41,7 +41,7 @@ public:
     {
         writeKeyValue(out, "version", version);
         writeKeyValue(out, "url", "http://oclint.org");
-        time_t now = time(0);
+        time_t now = time(nullptr);
         writeKeyValue(out, "timestamp", now);
     }
 

--- a/oclint-reporters/reporters/PMDReporter.cpp
+++ b/oclint-reporters/reporters/PMDReporter.cpp
@@ -8,12 +8,12 @@ using namespace oclint;
 class PMDReporter : public Reporter
 {
 public:
-    virtual const std::string name() const
+    virtual const std::string name() const override
     {
         return "pmd";
     }
 
-    virtual void report(Results *results, std::ostream &out)
+    virtual void report(Results* results, std::ostream& out) override
     {
         writeHeader(out, Version::identifier());
         for (const auto& violation : results->allViolations())

--- a/oclint-reporters/reporters/TextReporter.cpp
+++ b/oclint-reporters/reporters/TextReporter.cpp
@@ -8,12 +8,12 @@ using namespace oclint;
 class TextReporter : public Reporter
 {
 public:
-    virtual const std::string name() const
+    virtual const std::string name() const override
     {
         return "text";
     }
 
-    virtual void report(Results *results, std::ostream &out)
+    virtual void report(Results* results, std::ostream& out) override
     {
         if (results->hasErrors())
         {

--- a/oclint-reporters/reporters/XMLReporter.cpp
+++ b/oclint-reporters/reporters/XMLReporter.cpp
@@ -11,12 +11,12 @@ using namespace oclint;
 class XMLReporter : public Reporter
 {
 public:
-    virtual const std::string name() const
+    virtual const std::string name() const override
     {
         return "xml";
     }
 
-    virtual void report(Results *results, std::ostream &out)
+    virtual void report(Results* results, std::ostream& out) override
     {
         writeHeader(out, Version::identifier());
         writeDatetime(out);
@@ -39,7 +39,7 @@ public:
 
     void writeDatetime(std::ostream &out)
     {
-        time_t now = time(0);
+        time_t now = time(nullptr);
         struct tm *tmNow = gmtime(&now);
         char charNow[20];
         sprintf(charNow,

--- a/oclint-reporters/template/Reporter.tmpl
+++ b/oclint-reporters/template/Reporter.tmpl
@@ -5,12 +5,12 @@ using namespace oclint;
 class {{REPORTER_CLASS_NAME}}Reporter : public Reporter
 {
 public:
-    virtual const std::string name() const
+    virtual const std::string name() const override
     {
         return "{{REPORTER_NAME}}";
     }
 
-    virtual void report(Results *results, std::ostream &out)
+    virtual void report(Results *results, std::ostream &out) override
     {
     }
 };

--- a/oclint-rules/include/oclint/AbstractASTMatcherRule.h
+++ b/oclint-rules/include/oclint/AbstractASTMatcherRule.h
@@ -17,7 +17,8 @@ private:
     clang::ast_matchers::MatchFinder *_finder;
 
 protected:
-    virtual void run(const clang::ast_matchers::MatchFinder::MatchResult &result);
+    virtual void
+    run(const clang::ast_matchers::MatchFinder::MatchResult& result) override;
 
     template<typename T>
     void addMatcher(const T &nodeMatch)
@@ -26,13 +27,13 @@ protected:
     }
 
 public:
-    virtual void setUp();
+    virtual void setUp() override;
 
     bool VisitDecl(clang::Decl *decl);
 
     bool VisitStmt(clang::Stmt *stmt);
 
-    virtual void tearDown();
+    virtual void tearDown() override;
 
 public:
     virtual ~AbstractASTMatcherRule();

--- a/oclint-rules/include/oclint/AbstractSourceCodeReaderRule.h
+++ b/oclint-rules/include/oclint/AbstractSourceCodeReaderRule.h
@@ -9,7 +9,7 @@ namespace oclint
 class AbstractSourceCodeReaderRule : public RuleBase
 {
 protected:
-    virtual void apply();
+    virtual void apply() override;
 
     void addViolation(int startLine, int startColumn,
         int endLine, int endColumn, RuleBase *rule, const std::string& message = "");

--- a/oclint-rules/include/oclint/helper/SuppressHelper.h
+++ b/oclint-rules/include/oclint/helper/SuppressHelper.h
@@ -7,6 +7,7 @@
 
 bool shouldSuppress(const clang::Decl *decl, clang::ASTContext &context, oclint::RuleBase *rule);
 bool shouldSuppress(const clang::Stmt *stmt, clang::ASTContext &context, oclint::RuleBase *rule);
-bool shouldSuppress(int beginLine, clang::ASTContext &context, oclint::RuleBase *rule = NULL);
+bool shouldSuppress(int beginLine, clang::ASTContext& context,
+                    oclint::RuleBase* rule = nullptr);
 
 #endif

--- a/oclint-rules/lib/AbstractASTMatcherRule.cpp
+++ b/oclint-rules/lib/AbstractASTMatcherRule.cpp
@@ -35,7 +35,7 @@ bool AbstractASTMatcherRule::VisitStmt(clang::Stmt *stmt)
 void AbstractASTMatcherRule::tearDown()
 {
     delete _finder;
-    _finder = NULL;
+    _finder = nullptr;
 }
 
 } // end namespace oclint

--- a/oclint-rules/lib/helper/SuppressHelper.cpp
+++ b/oclint-rules/lib/helper/SuppressHelper.cpp
@@ -106,7 +106,7 @@ public:
 
 std::string getMainFilePath(clang::ASTContext &context)
 {
-    oclint::RuleCarrier ruleCarrier(&context, 0);
+    oclint::RuleCarrier ruleCarrier(&context, nullptr);
     return ruleCarrier.getMainFilePath();
 }
 
@@ -116,17 +116,16 @@ static LineMap singleLineMapping;
 bool lineBasedShouldSuppress(int beginLine, clang::ASTContext &context)
 {
     std::string filePath = getMainFilePath(context);
-    LineMap::iterator commentLinesIt = singleLineMapping.find(filePath);
+    auto commentLinesIt = singleLineMapping.find(filePath);
     std::set<int> commentLines;
     if (commentLinesIt == singleLineMapping.end())
     {
         clang::RawCommentList commentList = context.getRawCommentList();
         clang::ArrayRef<clang::RawComment *> commentArray = commentList.getComments();
 
-        for (clang::ArrayRef<clang::RawComment *>::iterator commentIt = commentArray.begin(),
-            itEnd = commentArray.end(); commentIt != itEnd; ++commentIt)
+        for (auto comment : commentArray)
         {
-            clang::RawComment *comment = *commentIt;
+
             if (std::string::npos !=
                 comment->getRawText(context.getSourceManager()).find("//!OCLINT"))
             {
@@ -152,7 +151,7 @@ static RangeMap rangeMapping;
 bool rangeBasedShouldSuppress(int beginLine, clang::ASTContext &context, oclint::RuleBase *rule)
 {
     std::string filePath = getMainFilePath(context);
-    RangeMap::iterator commentRangesIt = rangeMapping.find(filePath);
+    auto commentRangesIt = rangeMapping.find(filePath);
     RangeSet commentRanges;
     if (commentRangesIt == rangeMapping.end())
     {

--- a/oclint-rules/lib/util/ASTUtil.cpp
+++ b/oclint-rules/lib/util/ASTUtil.cpp
@@ -55,7 +55,8 @@ bool isObjCMethodDeclLocatedInInterfaceContainer(clang::ObjCMethodDecl *decl)
 bool isObjCMethodDeclInChildOfClass(
     const clang::ObjCMethodDecl* decl, const std::string& className) {
     const clang::ObjCInterfaceDecl* interface = decl->getClassInterface();
-    while(interface->getSuperClass() != NULL) {
+    while (interface->getSuperClass() != nullptr)
+    {
         interface = interface->getSuperClass();
         if(interface->getNameAsString() == className) {
             return true;

--- a/oclint-rules/rules/basic/BitwiseOperatorInConditionalRule.cpp
+++ b/oclint-rules/rules/basic/BitwiseOperatorInConditionalRule.cpp
@@ -13,17 +13,17 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "bitwise operator in conditional";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }
 
-    virtual void callback(const MatchFinder::MatchResult &result)
+    virtual void callback(const MatchFinder::MatchResult& result) override
     {
         const IfStmt *ifStmt = result.Nodes.getNodeAs<IfStmt>("ifStmt");
         if (ifStmt)
@@ -51,7 +51,7 @@ public:
         }
     }
 
-    virtual void setUpMatcher()
+    virtual void setUpMatcher() override
     {
         StatementMatcher biOpMatcher = binaryOperator(
             anyOf(hasOperatorName("&"), hasOperatorName("|"), hasOperatorName("^")));

--- a/oclint-rules/rules/basic/BrokenNullCheckRule.cpp
+++ b/oclint-rules/rules/basic/BrokenNullCheckRule.cpp
@@ -53,24 +53,25 @@ private:
     static RuleSet rules;
 
 protected:
-    virtual bool hasVariableInExpr(string variableOfInterest, Expr *expr)
+    virtual bool hasVariableInExpr(string variableOfInterest, Expr* expr)
+        override
     {
         VariableOfInterestInMemberExpr seekingVariable;
         return seekingVariable.hasVariableInExpr(variableOfInterest, expr, this);
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "broken null check";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 1;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_C | LANG_CXX;
     }
@@ -82,24 +83,25 @@ private:
     static RuleSet rules;
 
 protected:
-    virtual bool hasVariableInExpr(string variableOfInterest, Expr *expr)
+    virtual bool hasVariableInExpr(string variableOfInterest, Expr* expr)
+        override
     {
         VariableOfInterestInObjCMessageExpr seekingVariable;
         return seekingVariable.hasVariableInExpr(variableOfInterest, expr, this);
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "broken nil check";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/basic/BrokenOddnessCheckRule.cpp
+++ b/oclint-rules/rules/basic/BrokenOddnessCheckRule.cpp
@@ -30,12 +30,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "broken oddness check";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/basic/CollapsibleIfStatementsRule.cpp
+++ b/oclint-rules/rules/basic/CollapsibleIfStatementsRule.cpp
@@ -30,7 +30,7 @@ private:
                 return dyn_cast<IfStmt>(*(compoundStmt->body_begin()));
             }
         }
-        return NULL;
+        return nullptr;
     }
 
     bool checkElseBranch(IfStmt *outerIf, IfStmt *innerIf)
@@ -39,12 +39,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "collapsible if statements";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/basic/ConstantConditionalOperatorRule.cpp
+++ b/oclint-rules/rules/basic/ConstantConditionalOperatorRule.cpp
@@ -12,12 +12,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "constant conditional operator";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/basic/ConstantIfExpressionRule.cpp
+++ b/oclint-rules/rules/basic/ConstantIfExpressionRule.cpp
@@ -11,12 +11,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "constant if expression";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/basic/DeadCodeRule.cpp
+++ b/oclint-rules/rules/basic/DeadCodeRule.cpp
@@ -92,12 +92,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const std::string name() const
+    virtual const std::string name() const override
     {
         return "dead code";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/basic/DoubleNegativeRule.cpp
+++ b/oclint-rules/rules/basic/DoubleNegativeRule.cpp
@@ -21,12 +21,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "double negative";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/basic/ForLoopShouldBeWhileLoopRule.cpp
+++ b/oclint-rules/rules/basic/ForLoopShouldBeWhileLoopRule.cpp
@@ -11,12 +11,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "for loop should be while loop";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/basic/GotoStatementRule.cpp
+++ b/oclint-rules/rules/basic/GotoStatementRule.cpp
@@ -18,22 +18,22 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "goto statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual void callback(const MatchFinder::MatchResult &result)
+    virtual void callback(const MatchFinder::MatchResult& result) override
     {
         addViolation(result.Nodes.getNodeAs<GotoStmt>("gotoStmt"), this);
     }
 
-    virtual void setUpMatcher()
+    virtual void setUpMatcher() override
     {
         addMatcher(gotoStmt().bind("gotoStmt"));
     }

--- a/oclint-rules/rules/basic/JumbledIncrementerRule.cpp
+++ b/oclint-rules/rules/basic/JumbledIncrementerRule.cpp
@@ -17,7 +17,7 @@ private:
         {
             return dyn_cast_or_null<VarDecl>(declStmt->getSingleDecl());
         }
-        return NULL;
+        return nullptr;
     }
 
     ValueDecl *valueDeclFromIncExpr(Expr *incExpr)
@@ -32,7 +32,7 @@ private:
                 return declRefExpr->getDecl();
             }
         }
-        return NULL;
+        return nullptr;
     }
 
     bool isInnerIncMatchingOuterInit(Expr *incExpr, Stmt *initStmt)
@@ -43,12 +43,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "jumbled incrementer";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/basic/MisplacedNullCheckRule.cpp
+++ b/oclint-rules/rules/basic/MisplacedNullCheckRule.cpp
@@ -53,24 +53,25 @@ private:
     static RuleSet rules;
 
 protected:
-    virtual bool hasVariableInExpr(string variableOfInterest, Expr *expr)
+    virtual bool hasVariableInExpr(string variableOfInterest, Expr* expr)
+        override
     {
         VariableOfInterestInMemberExpr seekingVariable;
         return seekingVariable.hasVariableInExpr(variableOfInterest, expr, this);
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "misplaced null check";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 1;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_C | LANG_CXX;
     }
@@ -82,24 +83,25 @@ private:
     static RuleSet rules;
 
 protected:
-    virtual bool hasVariableInExpr(string variableOfInterest, Expr *expr)
+    virtual bool hasVariableInExpr(string variableOfInterest, Expr* expr)
+        override
     {
         VariableOfInterestInObjCMessageExpr seekingVariable;
         return seekingVariable.hasVariableInExpr(variableOfInterest, expr, this);
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "misplaced nil check";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/basic/MultipleUnaryOperatorRule.cpp
+++ b/oclint-rules/rules/basic/MultipleUnaryOperatorRule.cpp
@@ -19,12 +19,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "multiple unary operator";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/basic/ReturnFromFinallyBlockRule.cpp
+++ b/oclint-rules/rules/basic/ReturnFromFinallyBlockRule.cpp
@@ -30,12 +30,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "return from finally block";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/basic/ThrowExceptionFromFinallyBlockRule.cpp
+++ b/oclint-rules/rules/basic/ThrowExceptionFromFinallyBlockRule.cpp
@@ -66,17 +66,17 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "throw exception from finally block";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/cocoa/ObjCVerifyIsEqualHashRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyIsEqualHashRule.cpp
@@ -16,17 +16,17 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "must override hash with isEqual";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 1;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/cocoa/ObjCVerifyMustCallSuperRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyMustCallSuperRule.cpp
@@ -17,8 +17,9 @@ private:
     // Location to save found ivar accesses
     bool _foundSuperCall;
 public:
-
-    explicit ContainsCallToSuperMethod (string selectorString) : _selector(selectorString)  {
+    explicit ContainsCallToSuperMethod(string selectorString)
+        : _selector(std::move(selectorString))
+    {
         _foundSuperCall = false;
     }
 
@@ -46,8 +47,10 @@ private:
         if(decl->isOverriding()) {
             SmallVector<const ObjCMethodDecl*, 4> overridden;
             decl->getOverriddenMethods(overridden);
-            for(auto it = overridden.begin(), ite = overridden.end(); it != ite; ++it) {
-                if(declHasEnforceAttribute(*it, *this)) {
+            for (auto& elem : overridden)
+            {
+                if (declHasEnforceAttribute(elem, *this))
+                {
                     return true;
                 }
             }
@@ -56,17 +59,17 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "must call super";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 1;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/cocoa/ObjCVerifyProtectedMethodRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyProtectedMethodRule.cpp
@@ -72,21 +72,22 @@ public:
         return true;
     }
 
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "verify protected method";
     }
 
-    virtual const string attributeName() const {
+    virtual const string attributeName() const override
+    {
         return "protected method";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 1;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/cocoa/ObjCVerifySubclassMustImplementRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifySubclassMustImplementRule.cpp
@@ -17,18 +17,17 @@ private:
     static RuleSet rules;
 
 public:
-
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "subclass must implement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 1;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/convention/AvoidBranchingStatementAsLastInLoopRule.cpp
+++ b/oclint-rules/rules/convention/AvoidBranchingStatementAsLastInLoopRule.cpp
@@ -36,12 +36,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "avoid branching statement as last in loop";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/convention/CoveredSwitchStatementsDontNeedDefaultRule.cpp
+++ b/oclint-rules/rules/convention/CoveredSwitchStatementsDontNeedDefaultRule.cpp
@@ -12,12 +12,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "switch statements don't need default when fully covered";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/convention/DefaultLabelNotLastInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/DefaultLabelNotLastInSwitchStatementRule.cpp
@@ -12,12 +12,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "default label not last in switch statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/convention/DestructorOfVirtualClassRule.cpp
+++ b/oclint-rules/rules/convention/DestructorOfVirtualClassRule.cpp
@@ -14,17 +14,17 @@ class DestructorOfVirtualClassRule :
     public oclint::AbstractASTVisitorRule<DestructorOfVirtualClassRule>
 {
 public:
-    virtual const std::string name() const
+    virtual const std::string name() const override
     {
         return "destructor of virtual class";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }
 
-    unsigned int supportedLanguages() const
+    unsigned int supportedLanguages() const override
     {
         return oclint::LANG_CXX;
     }

--- a/oclint-rules/rules/convention/InvertedLogicRule.cpp
+++ b/oclint-rules/rules/convention/InvertedLogicRule.cpp
@@ -19,12 +19,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "inverted logic";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/convention/MissingBreakInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/MissingBreakInSwitchStatementRule.cpp
@@ -41,12 +41,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "missing break in switch statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/convention/NonCaseLabelInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/NonCaseLabelInSwitchStatementRule.cpp
@@ -31,12 +31,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "non case label in switch statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/convention/ObjCAssignIvarOutsideAccessorsRule.cpp
+++ b/oclint-rules/rules/convention/ObjCAssignIvarOutsideAccessorsRule.cpp
@@ -71,12 +71,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "ivar assignment outside accessors or init";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }
@@ -92,10 +92,8 @@ public:
 
         // Now go through all the ivar accesses and see
         // if they match the method name as a getter, setter, or init method
-        for (vector<ObjCIvarRefExpr*>::iterator it = checker.getInstances().begin();
-            it != checker.getInstances().end();
-            ++it) {
-            ObjCIvarRefExpr* access = *it;
+        for (auto& access : checker.getInstances())
+        {
             // ivarName is _foo or foo or foo_
             string ivarName = access->getDecl()->getNameAsString();
             // getterName is foo. Note this won't work for
@@ -106,7 +104,7 @@ public:
             if((selectorName != getterName
               && selectorName != setterName)
               && selectorName.substr(0, 4) != "init") {
-                addViolation(*it, this);
+                addViolation(access, this);
             }
         }
         return true;

--- a/oclint-rules/rules/convention/ParameterReassignmentRule.cpp
+++ b/oclint-rules/rules/convention/ParameterReassignmentRule.cpp
@@ -58,12 +58,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "parameter reassignment";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/convention/PreferEarlyExitRule.cpp
+++ b/oclint-rules/rules/convention/PreferEarlyExitRule.cpp
@@ -67,17 +67,17 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "use early exits and continue";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual void setUp()
+    virtual void setUp() override
     {
         _threshold = RuleConfiguration::intForKey("MAXIMUM_IF_LENGTH", 15);
     }

--- a/oclint-rules/rules/convention/SwitchStatementsShouldHaveDefaultRule.cpp
+++ b/oclint-rules/rules/convention/SwitchStatementsShouldHaveDefaultRule.cpp
@@ -12,12 +12,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "switch statements should have default";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/convention/TooFewBranchesInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/TooFewBranchesInSwitchStatementRule.cpp
@@ -33,12 +33,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "too few branches in switch statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/design/FeatureEnvyRule.cpp
+++ b/oclint-rules/rules/design/FeatureEnvyRule.cpp
@@ -185,12 +185,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "feature envy";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/empty/EmptyCatchStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyCatchStatementRule.cpp
@@ -13,12 +13,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "empty catch statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/empty/EmptyDoWhileStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyDoWhileStatementRule.cpp
@@ -13,12 +13,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "empty do/while statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/empty/EmptyElseBlockRule.cpp
+++ b/oclint-rules/rules/empty/EmptyElseBlockRule.cpp
@@ -13,12 +13,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "empty else block";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/empty/EmptyFinallyStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyFinallyStatementRule.cpp
@@ -13,12 +13,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "empty finally statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/empty/EmptyForStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyForStatementRule.cpp
@@ -13,12 +13,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "empty for statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/empty/EmptyIfStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyIfStatementRule.cpp
@@ -13,12 +13,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "empty if statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/empty/EmptySwitchStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptySwitchStatementRule.cpp
@@ -13,12 +13,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "empty switch statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/empty/EmptyTryStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyTryStatementRule.cpp
@@ -13,12 +13,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "empty try statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/empty/EmptyWhileStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyWhileStatementRule.cpp
@@ -13,12 +13,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "empty while statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/migration/ObjCBoxedExpressionsRule.cpp
+++ b/oclint-rules/rules/migration/ObjCBoxedExpressionsRule.cpp
@@ -13,7 +13,7 @@ private:
     bool isParenExprBox(Expr *expr,
         string &selectorString, map<string, string> &methodArgTypeMap)
     {
-        map<string, string>::iterator selectedSelector = methodArgTypeMap.find(selectorString);
+        auto selectedSelector = methodArgTypeMap.find(selectorString);
         return expr && isa<ParenExpr>(expr) &&
             selectedSelector != methodArgTypeMap.end() &&
             selectedSelector->second == dyn_cast<ParenExpr>(expr)->getType().getAsString();
@@ -80,17 +80,17 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "replace with boxed expression";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/migration/ObjCContainerLiteralsRule.cpp
+++ b/oclint-rules/rules/migration/ObjCContainerLiteralsRule.cpp
@@ -12,17 +12,17 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "replace with container literal";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/migration/ObjCNSNumberLiteralsRule.cpp
+++ b/oclint-rules/rules/migration/ObjCNSNumberLiteralsRule.cpp
@@ -24,7 +24,7 @@ private:
     template <typename T>
     bool isLiteralOf(Expr *expr, string &selectorString, map<string, string> &methodArgTypeMap)
     {
-        map<string, string>::iterator selectedSelector = methodArgTypeMap.find(selectorString);
+        auto selectedSelector = methodArgTypeMap.find(selectorString);
         return expr && isa<T>(expr) &&
             selectedSelector != methodArgTypeMap.end() &&
             selectedSelector->second == expr->getType().getAsString();
@@ -74,17 +74,17 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "replace with number literal";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/migration/ObjCObjectSubscriptingRule.cpp
+++ b/oclint-rules/rules/migration/ObjCObjectSubscriptingRule.cpp
@@ -52,17 +52,17 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "replace with object subscripting";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/naming/LongVariableNameRule.cpp
+++ b/oclint-rules/rules/naming/LongVariableNameRule.cpp
@@ -13,12 +13,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "long variable name";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/naming/ShortVariableNameRule.cpp
+++ b/oclint-rules/rules/naming/ShortVariableNameRule.cpp
@@ -53,12 +53,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "short variable name";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/redundant/RedundantConditionalOperatorRule.cpp
+++ b/oclint-rules/rules/redundant/RedundantConditionalOperatorRule.cpp
@@ -19,7 +19,7 @@ private:
         {
             return dyn_cast_or_null<nodeType>(implicitCastExpr->getSubExpr());
         }
-        return NULL;
+        return nullptr;
     }
 
     bool isCXXBoolNotEquals(Expr *trueExpr, Expr *falseExpr)
@@ -147,12 +147,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "redundant conditional operator";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/redundant/RedundantIfStatementRule.cpp
+++ b/oclint-rules/rules/redundant/RedundantIfStatementRule.cpp
@@ -25,7 +25,7 @@ private:
                 return extractStmt<nodeType>(*(dyn_cast<CompoundStmt>(fromStmt)->body_begin()));
             }
         }
-        return NULL;
+        return nullptr;
     }
 
     bool isCIntegerViolated(Expr *thenExpr, Expr *elseExpr)
@@ -77,12 +77,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "redundant if statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/redundant/RedundantLocalVariableRule.cpp
+++ b/oclint-rules/rules/redundant/RedundantLocalVariableRule.cpp
@@ -29,7 +29,7 @@ private:
 
             }
         }
-        return NULL;
+        return nullptr;
     }
 
     NamedDecl *extractNamedDecl(CompoundStmt *compoundStmt)
@@ -40,16 +40,16 @@ private:
         {
             return dyn_cast<NamedDecl>(declStmt->getSingleDecl());
         }
-        return NULL;
+        return nullptr;
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "redundant local variable";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/redundant/RedundantNilCheckRule.cpp
+++ b/oclint-rules/rules/redundant/RedundantNilCheckRule.cpp
@@ -41,17 +41,17 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "redundant nil check";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return LANG_OBJC;
     }

--- a/oclint-rules/rules/redundant/UnnecessaryElseStatementRule.cpp
+++ b/oclint-rules/rules/redundant/UnnecessaryElseStatementRule.cpp
@@ -74,17 +74,17 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "unnecessary else statement";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual void setUp()
+    virtual void setUp() override
     {
         _visitedIfStmt = new vector<IfStmt *>();
     }
@@ -97,7 +97,7 @@ public:
         }
         
         vector<IfStmt *> ifStmts;
-        Stmt *lastElseStmt = NULL;
+        Stmt* lastElseStmt = nullptr;
         bool stopSign = false;
 
         _visitedIfStmt->push_back(ifStmt);

--- a/oclint-rules/rules/redundant/UnnecessaryNullCheckForCXXDeallocRule.cpp
+++ b/oclint-rules/rules/redundant/UnnecessaryNullCheckForCXXDeallocRule.cpp
@@ -100,17 +100,17 @@ private:
     static oclint::RuleSet rules;
 
 public:
-    virtual const std::string name() const
+    virtual const std::string name() const override
     {
         return "unnecessary null check for cxxdealloc";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual unsigned int supportedLanguages() const
+    virtual unsigned int supportedLanguages() const override
     {
         return oclint::LANG_CXX;
     }

--- a/oclint-rules/rules/redundant/UselessParenthesesRule.cpp
+++ b/oclint-rules/rules/redundant/UselessParenthesesRule.cpp
@@ -19,12 +19,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "useless parentheses";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/size/CyclomaticComplexityRule.cpp
+++ b/oclint-rules/rules/size/CyclomaticComplexityRule.cpp
@@ -34,12 +34,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "high cyclomatic complexity";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/size/LongClassRule.cpp
+++ b/oclint-rules/rules/size/LongClassRule.cpp
@@ -27,17 +27,17 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "long class";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual void setUp()
+    virtual void setUp() override
     {
         _threshold = RuleConfiguration::intForKey("LONG_CLASS", 1000);
     }

--- a/oclint-rules/rules/size/LongLineRule.cpp
+++ b/oclint-rules/rules/size/LongLineRule.cpp
@@ -12,17 +12,17 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "long line";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual void eachLine(int lineNumber, string line)
+    virtual void eachLine(int lineNumber, string line) override
     {
         int threshold = RuleConfiguration::intForKey("LONG_LINE", 100);
         int currentLineSize = line.size();

--- a/oclint-rules/rules/size/LongMethodRule.cpp
+++ b/oclint-rules/rules/size/LongMethodRule.cpp
@@ -31,12 +31,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "long method";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/size/NPathComplexityRule.cpp
+++ b/oclint-rules/rules/size/NPathComplexityRule.cpp
@@ -40,12 +40,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "high npath complexity";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/size/NcssMethodCountRule.cpp
+++ b/oclint-rules/rules/size/NcssMethodCountRule.cpp
@@ -26,12 +26,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "high ncss method";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 2;
     }

--- a/oclint-rules/rules/size/NestedBlockDepthRule.cpp
+++ b/oclint-rules/rules/size/NestedBlockDepthRule.cpp
@@ -14,12 +14,12 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "deep nested block";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/size/TooManyFieldsRule.cpp
+++ b/oclint-rules/rules/size/TooManyFieldsRule.cpp
@@ -15,17 +15,17 @@ private:
     int _threshold;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "too many fields";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual void setUp()
+    virtual void setUp() override
     {
         _threshold = RuleConfiguration::intForKey("TOO_MANY_FIELDS", 20);
     }

--- a/oclint-rules/rules/size/TooManyMethodsRule.cpp
+++ b/oclint-rules/rules/size/TooManyMethodsRule.cpp
@@ -15,17 +15,17 @@ private:
     int _threshold;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "too many methods";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual void setUp()
+    virtual void setUp() override
     {
         _threshold = RuleConfiguration::intForKey("TOO_MANY_METHODS", 30);
     }

--- a/oclint-rules/rules/size/TooManyParametersRule.cpp
+++ b/oclint-rules/rules/size/TooManyParametersRule.cpp
@@ -27,17 +27,17 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "too many parameters";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }
 
-    virtual void setUp()
+    virtual void setUp() override
     {
         _threshold = RuleConfiguration::intForKey("TOO_MANY_PARAMETERS", 10);
     }

--- a/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
+++ b/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
@@ -58,12 +58,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "unused local variable";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/rules/unused/UnusedMethodParameterRule.cpp
+++ b/oclint-rules/rules/unused/UnusedMethodParameterRule.cpp
@@ -122,12 +122,12 @@ private:
     }
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "unused method parameter";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return 3;
     }

--- a/oclint-rules/template/ASTMatcherRule.tmpl
+++ b/oclint-rules/template/ASTMatcherRule.tmpl
@@ -13,21 +13,21 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "{{RULE_NAME}}";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return {{RULE_PRIORITY}};
     }
 
-    virtual void callback(const MatchFinder::MatchResult &result)
+    virtual void callback(const MatchFinder::MatchResult &result) override
     {
     }
 
-    virtual void setUpMatcher()
+    virtual void setUpMatcher() override
     {
     }
 

--- a/oclint-rules/template/ASTVisitorRule.tmpl
+++ b/oclint-rules/template/ASTVisitorRule.tmpl
@@ -11,18 +11,18 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "{{RULE_NAME}}";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return {{RULE_PRIORITY}};
     }
 
-    virtual void setUp() {}
-    virtual void tearDown() {}
+    virtual void setUp() override {}
+    virtual void tearDown() override {}
 
     {{VISIT_AST_NODE_BLOCK}}
 };

--- a/oclint-rules/template/GenericRule.tmpl
+++ b/oclint-rules/template/GenericRule.tmpl
@@ -12,17 +12,17 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "{{RULE_NAME}}";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return {{RULE_PRIORITY}};
     }
 
-    virtual void apply()
+    virtual void apply() override
     {
     }
 

--- a/oclint-rules/template/SourceCodeReaderRule.tmpl
+++ b/oclint-rules/template/SourceCodeReaderRule.tmpl
@@ -10,17 +10,17 @@ private:
     static RuleSet rules;
 
 public:
-    virtual const string name() const
+    virtual const string name() const override
     {
         return "{{RULE_NAME}}";
     }
 
-    virtual int priority() const
+    virtual int priority() const override
     {
         return {{RULE_PRIORITY}};
     }
 
-    virtual void eachLine(int lineNumber, string line)
+    virtual void eachLine(int lineNumber, string line) override
     {
     }
 };


### PR DESCRIPTION
I've run clang-modernize as suggested in #45 (previously named cpp11-migrate).

Changes include:
- adding override keyword on functions,
- replacing NULL with nullptr,
- enabling moves of some constructor parameters,
- replacing explicit type with auto where the type is obvious or unimportant,
- replacing loops over containers with range-based for.

I've also added explicit keyword to some single-param constructors and moved private static variables in RuleConfiguration and RuleSet to implementation files.
