### PR TITLE
Avoiding crash with readonly property

### DIFF
--- a/oclint-rules/rules/design/FeatureEnvyRule.cpp
+++ b/oclint-rules/rules/design/FeatureEnvyRule.cpp
@@ -92,7 +92,7 @@ class FeatureEnvyRule : public AbstractASTVisitorRule<FeatureEnvyRule>
 
         ObjCInterfaceDecl *getClassInterface(ObjCMethodDecl *decl)
         {
-            if (isa<ObjCProtocolDecl>(decl->getDeclContext()))
+            if (!decl || isa<ObjCProtocolDecl>(decl->getDeclContext()))
             {
                 return nullptr;
             }


### PR DESCRIPTION
Crash happens when a property defined as readonly has a setter defined
anyway in an extension, and code sets it using "self.property = ".
