### PR TITLE
Reorder #includes

### DIFF
--- a/oclint-core/lib/RuleCarrier.cpp
+++ b/oclint-core/lib/RuleCarrier.cpp
@@ -1,6 +1,6 @@
-#include <clang/AST/AST.h>
-
 #include "oclint/RuleCarrier.h"
+
+#include <clang/AST/AST.h>
 
 using namespace oclint;
 

--- a/oclint-core/lib/RuleSet.cpp
+++ b/oclint-core/lib/RuleSet.cpp
@@ -1,7 +1,8 @@
 #include "oclint/RuleSet.h"
-#include "oclint/RuleBase.h"
 
 #include <vector>
+
+#include "oclint/RuleBase.h"
 
 using namespace oclint;
 

--- a/oclint-core/lib/Violation.cpp
+++ b/oclint-core/lib/Violation.cpp
@@ -1,6 +1,8 @@
-#include "oclint/RuleBase.h"
 #include "oclint/Violation.h"
+
 #include <utility>
+
+#include "oclint/RuleBase.h"
 
 using namespace oclint;
 

--- a/oclint-driver/include/oclint/RulesetBasedAnalyzer.h
+++ b/oclint-driver/include/oclint/RulesetBasedAnalyzer.h
@@ -3,6 +3,8 @@
 
 #include "oclint/Analyzer.h"
 
+#include "oclint/RuleBase.h"
+
 namespace oclint
 {
 

--- a/oclint-driver/lib/CompilerInstance.cpp
+++ b/oclint-driver/lib/CompilerInstance.cpp
@@ -44,13 +44,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
  * SOFTWARE.
  */
+#include "oclint/CompilerInstance.h"
 
-#include <clang/Frontend/FrontendActions.h>
 #include <clang/Basic/TargetInfo.h>
-
+#include <clang/Frontend/FrontendActions.h>
 #include <clang/StaticAnalyzer/Frontend/FrontendActions.h>
 
-#include "oclint/CompilerInstance.h"
 #include "oclint/Options.h"
 
 using namespace oclint;

--- a/oclint-driver/lib/ConfigFile.cpp
+++ b/oclint-driver/lib/ConfigFile.cpp
@@ -1,7 +1,8 @@
-#include <llvm/Support/YAMLParser.h>
-#include <llvm/Support/SourceMgr.h>
-
 #include "oclint/ConfigFile.h"
+
+#include <llvm/Support/SourceMgr.h>
+#include <llvm/Support/YAMLParser.h>
+
 #include "oclint/Debug.h"
 
 using namespace oclint;

--- a/oclint-driver/lib/Debug.cpp
+++ b/oclint-driver/lib/Debug.cpp
@@ -1,7 +1,7 @@
+#include "oclint/Debug.h"
+
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/raw_ostream.h>
-
-#include "oclint/Debug.h"
 
 void oclint::debug::emit(const char *message)
 {

--- a/oclint-driver/lib/DiagnosticDispatcher.cpp
+++ b/oclint-driver/lib/DiagnosticDispatcher.cpp
@@ -1,10 +1,10 @@
+#include "oclint/DiagnosticDispatcher.h"
 
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/StringRef.h>
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Basic/SourceManager.h>
 
-#include "oclint/DiagnosticDispatcher.h"
 #include "oclint/Results.h"
 #include "oclint/Violation.h"
 

--- a/oclint-driver/lib/Driver.cpp
+++ b/oclint-driver/lib/Driver.cpp
@@ -44,6 +44,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
  * SOFTWARE.
  */
+#include "oclint/Driver.h"
 
 #include <unistd.h>
 
@@ -66,10 +67,9 @@
 #include <clang/Tooling/CompilationDatabase.h>
 #include <clang/Tooling/Tooling.h>
 
-#include "oclint/DiagnosticDispatcher.h"
 #include "oclint/CompilerInstance.h"
 #include "oclint/Debug.h"
-#include "oclint/Driver.h"
+#include "oclint/DiagnosticDispatcher.h"
 #include "oclint/GenericException.h"
 #include "oclint/Options.h"
 #include "oclint/ViolationSet.h"

--- a/oclint-driver/lib/GenericException.cpp
+++ b/oclint-driver/lib/GenericException.cpp
@@ -1,4 +1,5 @@
 #include "oclint/GenericException.h"
+
 #include <utility>
 
 using namespace oclint;

--- a/oclint-driver/lib/Options.cpp
+++ b/oclint-driver/lib/Options.cpp
@@ -1,3 +1,5 @@
+#include "oclint/Options.h"
+
 #include <unistd.h>
 
 #include <llvm/Option/OptTable.h>
@@ -11,7 +13,6 @@
 
 #include "oclint/ConfigFile.h"
 #include "oclint/Debug.h"
-#include "oclint/Options.h"
 #include "oclint/RuleConfiguration.h"
 
 using namespace oclint;

--- a/oclint-driver/lib/RulesetBasedAnalyzer.cpp
+++ b/oclint-driver/lib/RulesetBasedAnalyzer.cpp
@@ -1,11 +1,13 @@
+#include "oclint/RulesetBasedAnalyzer.h"
+
+#include <utility>
+
 #include "oclint/Debug.h"
 #include "oclint/Results.h"
 #include "oclint/RuleBase.h"
 #include "oclint/RuleCarrier.h"
 #include "oclint/RuleSet.h"
-#include "oclint/RulesetBasedAnalyzer.h"
 #include "oclint/ViolationSet.h"
-#include <utility>
 
 using namespace oclint;
 

--- a/oclint-driver/lib/RulesetFilter.cpp
+++ b/oclint-driver/lib/RulesetFilter.cpp
@@ -1,6 +1,7 @@
+#include "oclint/RulesetFilter.h"
+
 #include <algorithm>
 
-#include "oclint/RulesetFilter.h"
 #include "oclint/RuleSet.h"
 
 using namespace oclint;

--- a/oclint-rules/lib/util/StdUtil.cpp
+++ b/oclint-rules/lib/util/StdUtil.cpp
@@ -1,7 +1,6 @@
-#include <algorithm>
-
 #include "oclint/util/StdUtil.h"
 
+#include <algorithm>
 
 bool isUnderscore(char aChar) {
     return aChar == '_';

--- a/oclint-rules/rules/unused/UnusedMethodParameterRule.cpp
+++ b/oclint-rules/rules/unused/UnusedMethodParameterRule.cpp
@@ -1,8 +1,10 @@
 #include <sstream>
+
+#include <clang/AST/Attr.h>
+
 #include "oclint/AbstractASTVisitorRule.h"
 #include "oclint/RuleSet.h"
 #include "oclint/util/ASTUtil.h"
-#include <clang/AST/Attr.h>
 
 using namespace std;
 using namespace clang;


### PR DESCRIPTION
I have reordered includes (#115 - current file header first, than C and C++ standard library, than llvm, clang and finally oclint headers).
