### PR TITLE
Minor grammar fix for compiler errors in the text reporter

### DIFF
--- a/oclint-reporters/reporters/TextReporter.cpp
+++ b/oclint-reporters/reporters/TextReporter.cpp
@@ -19,8 +19,8 @@ public:
         if (results->hasErrors())
         {
             writeCompilerDiagnostics(out, results->allErrors(),
-                "Compiler Errors:\n(please aware that these errors "
-                "will prevent OCLint from analyzing those source code)");
+                "Compiler Errors:\n(please be aware that these errors "
+                "will prevent OCLint from analyzing this source code)");
         }
         if (results->hasWarnings())
         {


### PR DESCRIPTION
Makes two minor changes to the wording of the compiler error message in the text reporter so that it reads a little better.
