### PR TITLE
Catch up with clang driver changes

### DIFF
--- a/oclint-driver/lib/Driver.cpp
+++ b/oclint-driver/lib/Driver.cpp
@@ -87,11 +87,11 @@ static clang::driver::Driver *newDriver(clang::DiagnosticsEngine *diagnostics,
     return driver;
 }
 
-static std::string compilationJobsToString(const clang::driver::Job &job)
+static std::string compilationJobsToString(const clang::driver::JobList &jobs)
 {
     clang::SmallString<256> errorMsg;
     llvm::raw_svector_ostream errorStream(errorMsg);
-    job.Print(errorStream, "; ", true);
+    jobs.Print(errorStream, "; ", true);
     return errorStream.str();
 }
 


### PR DESCRIPTION
In r241310, the Job class was removed. For a job list, use the JobList class.