### PR TITLE
Allow the usage of the forward declarations within the code

### DIFF
--- a/oclint-rules/rules/convention/BaseClassDestructorShouldBeVirtualOrProtectedRule.cpp
+++ b/oclint-rules/rules/convention/BaseClassDestructorShouldBeVirtualOrProtectedRule.cpp
@@ -53,7 +53,9 @@ public:
 
     bool VisitCXXRecordDecl(const CXXRecordDecl* cxxRecordDecl)
     {
-        if (cxxRecordDecl != nullptr && cxxRecordDecl->isPolymorphic())
+        if (cxxRecordDecl != nullptr
+            && cxxRecordDecl->hasDefinition()
+            && cxxRecordDecl->isPolymorphic())
         {
             check(*cxxRecordDecl, cxxRecordDecl->bases_begin(), cxxRecordDecl->bases_end());
         }
@@ -75,7 +77,7 @@ private:
             }
             const CXXRecordDecl* baseClass = it->getType()->getAsCXXRecordDecl();
 
-            if (baseClass == nullptr)
+            if (baseClass == nullptr || baseClass->hasDefinition())
             {
                 continue;
             }

--- a/oclint-rules/rules/convention/DestructorOfVirtualClassRule.cpp
+++ b/oclint-rules/rules/convention/DestructorOfVirtualClassRule.cpp
@@ -38,6 +38,7 @@ public:
     bool VisitCXXRecordDecl(const CXXRecordDecl* cxxRecordDecl)
     {
         if (cxxRecordDecl != nullptr
+            && cxxRecordDecl->hasDefinition()
             && cxxRecordDecl->isPolymorphic()
             && !hasVirtualDestructor(*cxxRecordDecl))
         {


### PR DESCRIPTION
While Testing the code from a friend i ran into a segfault which can be tracked down with the following example code. This patch should fix the missbehaviour accordingly

Testcode
#include <iostream>

namespace a {
class aa;
}

int main(void) {

        std::cout << 1n;
        return 0;
}