### PR TITLE
Appended the suppression of unused local variables using RAII

### DIFF
--- a/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
+++ b/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
@@ -1,13 +1,58 @@
 #include <sstream>
+#include <set>
+#include <string>
 #include "oclint/AbstractASTVisitorRule.h"
 #include "oclint/RuleSet.h"
+#include "oclint/RuleConfiguration.h"
 
 using namespace std;
 using namespace clang;
 using namespace oclint;
 
+static set<string> skippedTypes;
+
+static void handleClassName(const string & className)
+{
+    //TODO verify the input
+    skippedTypes.insert(className);
+}
+
+static void splitClasses(const string & input) {
+    int startPos = 0;
+	// Take the string end into account, to avoid special string end handling
+    for (int i=0; i<input.length()+1; ++i)
+    {
+        for (auto const & curSep : { ',', ';', ' ', '\t', '\0' })
+        {
+            if (input[i] == curSep)
+            {
+                if (startPos != i)
+                {
+                    handleClassName(input.substr(startPos, i-startPos));
+                }
+                startPos = i+1;
+            }
+        }
+    }
+}
+
 class UnusedLocalVariableRule : public AbstractASTVisitorRule<UnusedLocalVariableRule>
 {
+public:
+    UnusedLocalVariableRule()
+    {
+        string defKeys = RuleConfiguration::stringForKey("RAII_DEFAULT_CLASSES",
+            "std::lock_guard, std::unique_lock");
+        string cusKeys = RuleConfiguration::stringForKey("RAII_CUSTOM_CLASSES", "");
+
+        for (auto const & curKeys : { defKeys, cusKeys })
+        {
+            if (!curKeys.empty())
+            {
+                splitClasses(curKeys);
+            }
+        }
+    }
 private:
     bool isInNonTemplateFunction(Decl *varDecl)
     {
@@ -70,7 +115,23 @@ public:
     {
         if (isUnusedLocalVariable(varDecl))
         {
-            addViolation(varDecl, this, description(varDecl->getNameAsString()));
+            // Getting ride of any template definition which might follow
+            auto varTypeName = varDecl->getType().getCanonicalType().getAsString();
+            auto const templPos = varTypeName.find('<');
+            if (templPos != string::npos) {
+                varTypeName = varTypeName.substr(0,templPos);
+            }
+            // Remove of the qualifiers, to get ride of class/struct/... definition parts
+            {
+                auto const lastSpacePos = varTypeName.rfind(' ');
+                if (lastSpacePos != string::npos) {
+                    varTypeName = varTypeName.substr(lastSpacePos + 1);
+                }
+            }
+            if (skippedTypes.find(varTypeName) == skippedTypes.end())
+            {
+                addViolation(varDecl, this, description(varDecl->getNameAsString()));
+            }
         }
         return true;
     }

--- a/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
+++ b/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
@@ -113,25 +113,27 @@ public:
 
     bool VisitVarDecl(VarDecl *varDecl)
     {
-        if (isUnusedLocalVariable(varDecl))
+        if (!isUnusedLocalVariable(varDecl))
         {
-            // Getting ride of any template definition which might follow
-            auto varTypeName = varDecl->getType().getCanonicalType().getAsString();
-            auto const templPos = varTypeName.find('<');
-            if (templPos != string::npos) {
-                varTypeName = varTypeName.substr(0,templPos);
+			return true;
+		}
+
+        // Getting ride of any template definition which might follow
+        auto varTypeName = varDecl->getType().getCanonicalType().getAsString();
+        auto const templPos = varTypeName.find('<');
+        if (templPos != string::npos) {
+            varTypeName = varTypeName.substr(0,templPos);
+        }
+        // Remove of the qualifiers, to get ride of class/struct/... definition parts
+        {
+            auto const lastSpacePos = varTypeName.rfind(' ');
+            if (lastSpacePos != string::npos) {
+                varTypeName = varTypeName.substr(lastSpacePos + 1);
             }
-            // Remove of the qualifiers, to get ride of class/struct/... definition parts
-            {
-                auto const lastSpacePos = varTypeName.rfind(' ');
-                if (lastSpacePos != string::npos) {
-                    varTypeName = varTypeName.substr(lastSpacePos + 1);
-                }
-            }
-            if (skippedTypes.find(varTypeName) == skippedTypes.end())
-            {
-                addViolation(varDecl, this, description(varDecl->getNameAsString()));
-            }
+        }
+        if (skippedTypes.find(varTypeName) == skippedTypes.end())
+        {
+            addViolation(varDecl, this, description(varDecl->getNameAsString()));
         }
         return true;
     }


### PR DESCRIPTION
This changes allow to suppress the complains about unused variables.
When using RAII such as std::lock_guard the intention of do not access the variable further is intended

There are two variables, which allow to change the baviour:
RAII_DEFAULT_CLASSES which suppress std::lock_guard and std::unique_lock
RAII_CUSTOM_CLASSES to allow the user to define further own created parts

At the moment there are no tests appended and maybe further classes should be appended to the default definition