### PR TITLE
Appended a few tests for RAII support

### DIFF
--- a/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
+++ b/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
@@ -1,6 +1,7 @@
 #include <sstream>
 #include <set>
 #include <string>
+#include <list>
 #include "oclint/AbstractASTVisitorRule.h"
 #include "oclint/RuleSet.h"
 #include "oclint/RuleConfiguration.h"
@@ -51,7 +52,22 @@ public:
             "std::lock_guard, std::unique_lock");
         string cusKeys = RuleConfiguration::stringForKey("RAII_CUSTOM_CLASSES", "");
 
-        for (auto const & curKeys : { defKeys, cusKeys })
+        resetSkippedTypes( { defKeys, cusKeys });
+    }
+protected:
+    /*
+     * Replace the list of known splitting classes and assign new values based on the parameter
+     *
+     * The main purpose of this class is to allow tests with different rule configurations
+     * In the regular operation mode, this part should be only triggered within the ctor
+     *
+     * @param newIgnoreTypes The new types to insert accordingly
+     * @throw std::invalid_argument, in case that the given input contains a failure
+     */
+    void resetSkippedTypes(const std::list<string> & newIgnoreTypes)
+    {
+        skippedTypes.clear();
+        for (auto const & curKeys : newIgnoreTypes)
         {
             if (!curKeys.empty())
             {

--- a/oclint-rules/test/unused/UnusedLocalVariableRuleTest.cpp
+++ b/oclint-rules/test/unused/UnusedLocalVariableRuleTest.cpp
@@ -73,8 +73,53 @@ public:\n\
     lock_guard(mutex_type& m, adopt_lock_t);\n\
     ~lock_guard();\n\
 };\n\
+template <class Mutex>\n\
+class unique_lock\n\
+{\n\
+public:\n\
+    typedef Mutex mutex_type;\n\
+    explicit unique_lock(mutex_type& m);\n\
+    unique_lock(mutex_type& m, adopt_lock_t);\n\
+    ~unique_lock();\n\
+};\n\
 adopt_lock_t adopt_lock;\n\
 } // namespace std\n";
+
+static const std::string stdMutexCodePre = stdMutexHeader + "\
+class TestClassA\n\
+{\n\
+};\n\
+namespace testNamespace\n\
+{\n\
+class TestClassB\n\
+{\n\
+};\n\
+}\n\
+int m() {\n\
+    std::mutex mtx;\n\
+";
+
+static const std::string stdMutexCodePost = "\n\
+    return 5;\n\
+}";
+
+
+/*
+ Define a test which is used to the UnusedLocalVariableRule class
+
+ This ensures, that it is possible, to set and modify the RAII classes taken into
+ account, while keep the possiblity to run the tests in parallel. At least the
+ GoogleTest manual advice to do it in this way.
+*/
+class UnusedLocalVariableRuleTest : public UnusedLocalVariableRule
+{
+public:
+    UnusedLocalVariableRuleTest(const std::list<std::string> & newSuppressClasses)
+    {
+        resetSkippedTypes(newSuppressClasses);
+    }
+};
+
 
 TEST(UnusedLocalVariableRuleTest, IgnoreRAIITechniqueInWhitelist)
 {
@@ -83,9 +128,104 @@ TEST(UnusedLocalVariableRuleTest, IgnoreRAIITechniqueInWhitelist)
 
 TEST(UnusedLocalVariableRuleTest, RAIITechniqueWhitelistDifferentNumOfParameters)
 {
-    testRuleOnCXXCode(new UnusedLocalVariableRule(), stdMutexHeader + "int m() { static std::mutex mutex; std::lock_guard<std::mutex> lock(mutex, std::adopt_lock); return 1; }",
-        0, 21, 36, 21, 91, "The local variable 'lock' is unused.");
+    testRuleOnCXXCode(new UnusedLocalVariableRule(), stdMutexHeader + "int m() { static std::mutex mutex; std::lock_guard<std::mutex> lock(mutex, std::adopt_lock); return 1; }");
 }
+
+TEST(UnusedLocalVariableRuleTest, RAIITechniqueDefaultParameters)
+{
+    testRuleOnCXXCode(new UnusedLocalVariableRule(),
+        stdMutexCodePre +
+            "{ std::lock_guard<std::mutex> lock (mtx);  }\n"
+            "{ std::unique_lock<std::mutex> lock (mtx); }\n"
+            VIOLATION_START "TestClassA " VIOLATION_END "testObjA;\n"
+            VIOLATION_START "testNamespace::TestClassB " VIOLATION_END "testObjB;\n"
+            VIOLATION_START "int iii = " VIOLATION_END "12;\n"
+        + stdMutexCodePost,
+        {
+            "The local variable 'testObjA' is unused.",
+            "The local variable 'testObjB' is unused.",
+            "The local variable 'iii' is unused.",
+        }
+    );
+}
+
+TEST(UnusedLocalVariableRuleTest, RAIITechniqueDefaultParametersExplicite)
+{
+    testRuleOnCXXCode(new UnusedLocalVariableRuleTest({"std::lock_guard std::unique_lock"}),
+        stdMutexCodePre +
+            "{ std::lock_guard<std::mutex> lock (mtx);  }\n"
+            "{ std::unique_lock<std::mutex> lock (mtx); }\n"
+            VIOLATION_START "TestClassA " VIOLATION_END "testObjA;\n"
+            VIOLATION_START "testNamespace::TestClassB " VIOLATION_END "testObjB;\n"
+            VIOLATION_START "int iii = " VIOLATION_END "12;\n"
+        + stdMutexCodePost,
+        {
+            "The local variable 'testObjA' is unused.",
+            "The local variable 'testObjB' is unused.",
+            "The local variable 'iii' is unused.",
+        }
+    );
+}
+
+
+TEST(UnusedLocalVariableRuleTest, RAIITechniqueCustomValuesWithoutFullNamespace)
+{
+    testRuleOnCXXCode(new UnusedLocalVariableRuleTest({"std::lock_guard std::unique_lock", "TestClassA TestClassB"}),
+        stdMutexCodePre +
+            "{ std::lock_guard<std::mutex> lock (mtx);  }\n"
+            "{ std::unique_lock<std::mutex> lock (mtx); }\n"
+            "TestClassA testObjA;\n"
+            VIOLATION_START "testNamespace::TestClassB " VIOLATION_END "testObjB;\n"
+            VIOLATION_START "int iii = " VIOLATION_END "12;\n"
+        + stdMutexCodePost,
+        {
+            "The local variable 'testObjB' is unused.",
+            "The local variable 'iii' is unused.",
+        }
+    );
+}
+
+
+TEST(UnusedLocalVariableRuleTest, RAIITechniqueCustomValuesWithFullNamespace)
+{
+    testRuleOnCXXCode(new UnusedLocalVariableRuleTest({
+        "std::lock_guard std::unique_lock",
+        "TestClassA testNamespace::TestClassB"
+    }),
+        stdMutexCodePre +
+            "{ std::lock_guard<std::mutex> lock (mtx);  }\n"
+            "{ std::unique_lock<std::mutex> lock (mtx); }\n"
+            "TestClassA testObjA;\n"
+            "testNamespace::TestClassB testObjB;\n"
+            VIOLATION_START "int iii = " VIOLATION_END "12;\n"
+        + stdMutexCodePost,
+        {
+            "The local variable 'iii' is unused.",
+        }
+    );
+}
+
+TEST(UnusedLocalVariableRuleTest, RAIITechniqueCustomValuesWithFullNamespaceWithoutDefault)
+{
+    testRuleOnCXXCode(new UnusedLocalVariableRuleTest({
+        "",
+        "TestClassA testNamespace::TestClassB"
+    }),
+        stdMutexCodePre +
+            "{" VIOLATION_START "std::lock_guard<std::mutex>  lock (mtx" VIOLATION_END "); }\n"
+            "{" VIOLATION_START "std::unique_lock<std::mutex> lock (mtx" VIOLATION_END "); }\n"
+            "TestClassA testObjA;\n"
+            "testNamespace::TestClassB testObjB;\n"
+            VIOLATION_START "int iii = " VIOLATION_END "12;\n"
+        + stdMutexCodePost,
+        {
+            "The local variable 'lock' is unused.",
+            "The local variable 'lock' is unused.",
+            "The local variable 'iii' is unused.",
+        }
+    );
+}
+
 
 TEST(UnusedLocalVariableRuleTest, SuppressUnusedLocalVariable)
 {


### PR DESCRIPTION
Sorry for the long delay and not appending tests on the first pull requests.

I've now appended a few of them. At the moment it seems like they are not working, after a complete rebase. Seems like it is related to the appending of those two lines:
+        CXXConstructExpr* expr = dyn_cast_or_null<CXXConstructExpr>(varDecl->getInit());
+        return expr && expr->getNumArgs() == 1;

As i am not sure what the intention of them is, they might need a check. At least the things look fine up to those lines. If I have not done something wrong, the test should pass without any complains (at least they do without them)