### PR TITLE
Allow spaces and varied case in suppress comments

### DIFF
--- a/oclint-rules/lib/helper/SuppressHelper.cpp
+++ b/oclint-rules/lib/helper/SuppressHelper.cpp
@@ -1,5 +1,6 @@
 #include "oclint/helper/SuppressHelper.h"
 
+#include <regex>
 #include <set>
 #include <unordered_map>
 #include <utility>
@@ -125,9 +126,9 @@ bool lineBasedShouldSuppress(int beginLine, clang::ASTContext &context)
 
         for (auto comment : commentArray)
         {
-
-            if (std::string::npos !=
-                comment->getRawText(context.getSourceManager()).find("//!OCLINT"))
+            std::string commentString = comment->getRawText(context.getSourceManager()).str();
+            std::regex oclintRegex = std::regex("//! *OCLINT", std::regex::basic | std::regex::icase);
+            if (std::regex_search(commentString, oclintRegex))
             {
                 clang::SourceLocation startLocation = comment->getLocStart();
                 int startLocationLine =

--- a/oclint-rules/test/helper/SuppressHelperTest.cpp
+++ b/oclint-rules/test/helper/SuppressHelperTest.cpp
@@ -106,11 +106,17 @@ TEST(SuppressHelperTestASTRuleTest, ObjCContainerSuppressOnMethod)
 TEST(SuppressHelperTestASTRuleTest, SimpleNOLINT)
 {
     testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //!OCLINT");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //! OCLINT");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //!OCLint");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //! OCLint");
 }
 
 TEST(SuppressHelperTestASTRuleTest, MultipleLineNOLINT)
 {
     testRuleOnCode(new SuppressHelperTestASTRule(), "void a() { //!OCLINT\n if (1) {//!OCLINT\n}}");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() { //! OCLINT\n if (1) {//! OCLINT\n}}");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() { //!OCLint\n if (1) {//!OCLint\n}}");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() { //! OCLint\n if (1) {//! OCLint\n}}");
 }
 
 TEST(SuppressHelperTestASTRuleTest, CommentWithDescriptionNOLINT)
@@ -119,6 +125,18 @@ TEST(SuppressHelperTestASTRuleTest, CommentWithDescriptionNOLINT)
     testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //!OCLINT[reason for suppressing this is blahblah]");
     testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //!OCLINT:reason for suppressing this is blahblah)");
     testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //!OCLINT     ");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //! OCLINT(reason for suppressing this is blahblah)");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //! OCLINT[reason for suppressing this is blahblah]");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //! OCLINT:reason for suppressing this is blahblah)");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //! OCLINT     ");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //!OCLint(reason for suppressing this is blahblah)");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //!OCLint[reason for suppressing this is blahblah]");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //!OCLint:reason for suppressing this is blahblah)");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //!OCLint     ");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //! OCLint(reason for suppressing this is blahblah)");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //! OCLint[reason for suppressing this is blahblah]");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //! OCLint:reason for suppressing this is blahblah)");
+    testRuleOnCode(new SuppressHelperTestASTRule(), "void a() {} //! OCLint     ");
 }
 
 class SuppressHelperTestSourceCodeReaderRule : public AbstractSourceCodeReaderRule
@@ -160,6 +178,9 @@ TEST(SuppressHelperTestSourceCodeReaderRuleTest, NoSuppress)
 TEST(SuppressHelperTestSourceCodeReaderRuleTest, SuppressByComment)
 {
     testRuleOnCode(new SuppressHelperTestSourceCodeReaderRule(), "void a() {} //!OCLINT");
+    testRuleOnCode(new SuppressHelperTestSourceCodeReaderRule(), "void a() {} //! OCLINT");
+    testRuleOnCode(new SuppressHelperTestSourceCodeReaderRule(), "void a() {} //!OCLint");
+    testRuleOnCode(new SuppressHelperTestSourceCodeReaderRule(), "void a() {} //! OCLint");
 }
 
 TEST(SuppressHelperTestSourceCodeReaderRuleTest, SuppressEntireMethod)


### PR DESCRIPTION
[Official documentation](http://oclint-docs.readthedocs.org/en/stable/howto/suppress.html) has example of both `//!OCLINT` and `//!OCLint` warnings suppress comments.
However, actual implementation supports only `//!OCLINT`.
A bit confusing, takes a while to figure out that documentation is wrong.

This change will use case-insensitive check for "oclint" match.
Additionally, it allows to have space after `//!`, e.g. `//! OCLINT`, which is a valid form of raw comment.

P.S.
Stuff like `//!         oclint` will also work, but it's rather undocumented feature :).