### PR TITLE
[WIP] Improve travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 os:
 - linux
 - osx
+env:
+  - MODULE="core"
+  - MODULE="metrics"
+  - MODULE="rules" DEP="core metrics"
+  - MODULE="reporters" DEP="core"
+
 language: cpp
 sudo: required
 dist: trusty
@@ -9,4 +15,4 @@ before_install:
 - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install cmake; fi
 script:
   - cd oclint-scripts
-  - ./travis
+  - ./travis $MODULE $DEP

--- a/oclint-rules/test/CMakeLists.txt
+++ b/oclint-rules/test/CMakeLists.txt
@@ -1,7 +1,9 @@
+ADD_LIBRARY(test_helper headers/TestRuleOnCode.cpp)
 MACRO(build_test name)
     ADD_EXECUTABLE(${name} ${name}.cpp)
     IF (MINGW)
         TARGET_LINK_LIBRARIES(${name}
+            test_helper
             gmock
             ${PROFILE_RT_LIBS}
             ${CLANG_LIBRARIES}
@@ -13,6 +15,7 @@ MACRO(build_test name)
         )
     ELSE()
         TARGET_LINK_LIBRARIES(${name}
+            test_helper
             OCLintAbstractRule
             OCLintMetric
             OCLintHelper

--- a/oclint-rules/test/headers/TestRuleOnCode.cpp
+++ b/oclint-rules/test/headers/TestRuleOnCode.cpp
@@ -1,0 +1,249 @@
+#include "TestRuleOnCode.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace ::testing;
+
+#include "TestEngine.h"
+
+bool computeViolationSet(const Twine &fileName,
+    RuleBase *rule,
+    const std::string &code,
+    const std::vector<std::string> &args,
+    ViolationSet *violationSet)
+{
+    FrontendAction* action = new TestFrontendAction(rule, violationSet);
+    Twine twine(code);
+
+    const std::size_t randomPrefixLength = 6;
+    std::string randomPrefix(randomPrefixLength, 0);
+    const char randomChars[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const size_t randomCharSize = sizeof(randomChars) - 1;
+
+    std::generate_n(randomPrefix.begin(), randomPrefixLength,
+        [randomChars, randomCharSize]() -> char { return randomChars[rand() % randomCharSize]; });
+    return runToolOnCodeWithArgs(action, twine, args, randomPrefix + fileName);
+}
+
+void validateViolation(const Violation& violation,
+    int expectStartLine,
+    int expectStartColumn,
+    int expectEndLine,
+    int expectEndColumn,
+    const string& expectMessage)
+{
+    EXPECT_THAT(violation.startLine, Eq(expectStartLine));
+    EXPECT_THAT(violation.startColumn, Eq(expectStartColumn));
+    EXPECT_THAT(violation.endLine, Eq(expectEndLine));
+    EXPECT_THAT(violation.endColumn, Eq(expectEndColumn));
+    EXPECT_THAT(violation.message, StrEq(expectMessage));
+}
+
+void testRuleOnCode(const Twine &fileName,
+    RuleBase *rule,
+    const string &code,
+    const std::vector<std::string> &args,
+    int violationIndex,
+    int startLine,
+    int startColumn,
+    int endLine,
+    int endColumn,
+    const string& message)
+{
+    ViolationSet violationSet;
+
+    if (computeViolationSet(fileName, rule, code, args, &violationSet))
+    {
+        const vector<Violation>& violations = violationSet.getViolations();
+
+        if (violationIndex < 0)
+        {
+            EXPECT_THAT(violations.size(), Eq(0u));
+        }
+        else
+        {
+            EXPECT_LT(size_t(violationIndex), violations.size());
+            if (size_t(violationIndex) < violations.size())
+            {
+                const Violation& violation = violations.at(violationIndex);
+                validateViolation(violation, startLine, startColumn, endLine, endColumn, message);
+            }
+        }
+    }
+    else
+    {
+        FAIL();
+    }
+}
+
+void testRuleOnCode(RuleBase *rule,
+    const string &code,
+    int violationIndex,
+    int expectStartLine,
+    int expectStartColumn,
+    int expectEndLine,
+    int expectEndColumn,
+    const string& expectMessage)
+{
+    testRuleOnCode("input.c", rule, code, {}, violationIndex,
+        expectStartLine, expectStartColumn, expectEndLine, expectEndColumn, expectMessage);
+}
+
+void testRuleOnCXXCode(RuleBase *rule,
+    const string &code,
+    int violationIndex,
+    int expectStartLine,
+    int expectStartColumn,
+    int expectEndLine,
+    int expectEndColumn,
+    const string& expectMessage)
+{
+    testRuleOnCode("input.cpp", rule, code, {}, violationIndex,
+        expectStartLine, expectStartColumn, expectEndLine, expectEndColumn, expectMessage);
+}
+
+void testRuleOnCXX11Code(RuleBase *rule,
+    const string &code,
+    int violationIndex,
+    int expectStartLine,
+    int expectStartColumn,
+    int expectEndLine,
+    int expectEndColumn,
+    const string& expectMessage)
+{
+    testRuleOnCode("input.cpp", rule, code, {"-std=c++11"}, violationIndex,
+        expectStartLine, expectStartColumn, expectEndLine, expectEndColumn, expectMessage);
+}
+
+void testRuleOnObjCCode(RuleBase *rule,
+    const string &code,
+    int violationIndex,
+    int expectStartLine,
+    int expectStartColumn,
+    int expectEndLine,
+    int expectEndColumn,
+    const string& expectMessage)
+{
+    testRuleOnCode("input.m", rule, code, {}, violationIndex,
+        expectStartLine, expectStartColumn, expectEndLine, expectEndColumn, expectMessage);
+}
+
+void ComputeLocalisation(const std::string& code, size_t offset, int* line, int* column)
+{
+    int currentColumn = 1;
+    int currentLine = 1;
+
+    for (size_t i = 0; i != offset; ++i)
+    {
+        if (code[i] == '\n')
+        {
+            currentColumn = 1;
+            ++currentLine;
+        }
+        else
+        {
+            ++currentColumn;
+        }
+    }
+    *line = currentLine;
+    *column = currentColumn;
+}
+
+// {start/end offset} ordered by increasing start-location then end-location.
+std::vector<std::pair<size_t, size_t>> extractViolationLocations(std::string& code)
+{
+    size_t findOffset = 0;
+    std::vector<size_t> startOffsets;
+    std::vector<std::pair<size_t,size_t>> rangeOffsets;
+
+    for (;;)
+    {
+        const size_t startOffset = code.find(VIOLATION_START, findOffset);
+        const size_t endOffset = code.find(VIOLATION_END, findOffset);
+        if (startOffset == std::string::npos && endOffset == std::string::npos)
+        {
+            assert(startOffsets.empty());
+            std::sort(rangeOffsets.begin(), rangeOffsets.end());
+            return rangeOffsets;
+        }
+        if (startOffset < endOffset)
+        {
+            code.erase(startOffset, strlen(VIOLATION_START));
+            startOffsets.push_back(startOffset);
+            findOffset = startOffset;
+        }
+        else
+        {
+            code.erase(endOffset, strlen(VIOLATION_END));
+            assert(!startOffsets.empty());
+            rangeOffsets.push_back({startOffsets.back(), endOffset});
+            startOffsets.pop_back();
+            findOffset = endOffset;
+        }
+    }
+}
+
+bool lessByLocation(const Violation& lhs, const Violation& rhs)
+{
+    if (lhs.startLine != rhs.startLine) return lhs.startLine < rhs.startLine;
+    if (lhs.startColumn != rhs.startColumn) return lhs.startColumn < rhs.startColumn;
+    if (lhs.endLine != rhs.endLine) return lhs.endLine < rhs.endLine;
+    if (lhs.endColumn != rhs.endColumn) return lhs.endColumn < rhs.endColumn;
+    return lhs.message < rhs.message;
+}
+
+void testRuleOnCode(const Twine& filename,
+    const std::vector<std::string>& args,
+    RuleBase* rule,
+    std::string code,
+    const std::vector<std::string>& messages)
+{
+    const auto& rangeOffsets = extractViolationLocations(code);
+    ViolationSet violationSet;
+
+    if (!computeViolationSet(filename, rule, code, args, &violationSet))
+    {
+        FAIL();
+        return;
+    }
+    vector<Violation> violations = violationSet.getViolations();
+
+    ASSERT_THAT(violations.size(), Eq(rangeOffsets.size()));
+
+    std::sort(violations.begin(), violations.end(), &lessByLocation);
+    for (size_t i = 0; i != rangeOffsets.size(); ++i)
+    {
+        const Violation& violation = violations[i];
+        const size_t startOffset = rangeOffsets[i].first;
+        const size_t endOffset = rangeOffsets[i].second;
+        const std::string& message = i < messages.size() ? messages[i] : "";
+        int startLine, startColumn, endLine, endColumn;
+        ComputeLocalisation(code, startOffset, &startLine, &startColumn);
+        ComputeLocalisation(code, endOffset, &endLine, &endColumn);
+        validateViolation(violation, startLine, startColumn, endLine, endColumn, message);
+    }
+}
+
+void testRuleOnCode(RuleBase* rule, std::string code,
+    const std::vector<std::string>& messages)
+{
+    testRuleOnCode("input.c", {}, rule, code, messages);
+}
+
+void testRuleOnCXXCode(RuleBase* rule, std::string code,
+    const std::vector<std::string>& messages)
+{
+    testRuleOnCode("input.cpp", {}, rule, code, messages);
+}
+
+void testRuleOnCXX11Code(RuleBase* rule, std::string code,
+    const std::vector<std::string>& messages)
+{
+    testRuleOnCode("input.cpp", {"-std=c++11"}, rule, code, messages);
+}
+
+void testRuleOnObjCCode(RuleBase* rule, std::string code,
+    const std::vector<std::string>& messages)
+{
+    testRuleOnCode("input.m", {}, rule, code, messages);
+}

--- a/oclint-rules/test/headers/TestRuleOnCode.h
+++ b/oclint-rules/test/headers/TestRuleOnCode.h
@@ -1,37 +1,32 @@
-inline bool computeViolationSet(const Twine &fileName,
+#include <vector>
+#include <string>
+
+using namespace std;
+
+#include <clang/Tooling/Tooling.h>
+
+using namespace llvm;
+using namespace clang;
+using namespace clang::tooling;
+
+#include "oclint/RuleBase.h"
+
+using namespace oclint;
+
+bool computeViolationSet(const Twine &fileName,
     RuleBase *rule,
     const std::string &code,
     const std::vector<std::string> &args,
-    ViolationSet *violationSet)
-{
-    FrontendAction* action = new TestFrontendAction(rule, violationSet);
-    Twine twine(code);
+    ViolationSet *violationSet);
 
-    const std::size_t randomPrefixLength = 6;
-    std::string randomPrefix(randomPrefixLength, 0);
-    const char randomChars[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    const size_t randomCharSize = sizeof(randomChars) - 1;
-
-    std::generate_n(randomPrefix.begin(), randomPrefixLength,
-        [randomChars, randomCharSize]() -> char { return randomChars[rand() % randomCharSize]; });
-    return runToolOnCodeWithArgs(action, twine, args, randomPrefix + fileName);
-}
-
-inline void validateViolation(const Violation& violation,
+void validateViolation(const Violation& violation,
     int expectStartLine,
     int expectStartColumn,
     int expectEndLine,
     int expectEndColumn,
-    const string& expectMessage = "")
-{
-    EXPECT_THAT(violation.startLine, Eq(expectStartLine));
-    EXPECT_THAT(violation.startColumn, Eq(expectStartColumn));
-    EXPECT_THAT(violation.endLine, Eq(expectEndLine));
-    EXPECT_THAT(violation.endColumn, Eq(expectEndColumn));
-    EXPECT_THAT(violation.message, StrEq(expectMessage));
-}
+    const string& expectMessage = "");
 
-inline void testRuleOnCode(const Twine &fileName,
+void testRuleOnCode(const Twine &fileName,
     RuleBase *rule,
     const string &code,
     const std::vector<std::string> &args,
@@ -40,85 +35,43 @@ inline void testRuleOnCode(const Twine &fileName,
     int startColumn,
     int endLine,
     int endColumn,
-    const string& message = "")
-{
-    ViolationSet violationSet;
+    const string& message = "");
 
-    if (computeViolationSet(fileName, rule, code, args, &violationSet))
-    {
-        const vector<Violation>& violations = violationSet.getViolations();
-
-        if (violationIndex < 0)
-        {
-            EXPECT_THAT(violations.size(), Eq(0u));
-        }
-        else
-        {
-            EXPECT_LT(size_t(violationIndex), violations.size());
-            if (size_t(violationIndex) < violations.size())
-            {
-                const Violation& violation = violations.at(violationIndex);
-                validateViolation(violation, startLine, startColumn, endLine, endColumn, message);
-            }
-        }
-    }
-    else
-    {
-        FAIL();
-    }
-}
-
-inline void testRuleOnCode(RuleBase *rule,
+void testRuleOnCode(RuleBase *rule,
     const string &code,
     int violationIndex,
     int expectStartLine,
     int expectStartColumn,
     int expectEndLine,
     int expectEndColumn,
-    const string& expectMessage = "")
-{
-    testRuleOnCode("input.c", rule, code, {}, violationIndex,
-        expectStartLine, expectStartColumn, expectEndLine, expectEndColumn, expectMessage);
-}
+    const string& expectMessage = "");
 
-inline void testRuleOnCXXCode(RuleBase *rule,
+void testRuleOnCXXCode(RuleBase *rule,
     const string &code,
     int violationIndex,
     int expectStartLine,
     int expectStartColumn,
     int expectEndLine,
     int expectEndColumn,
-    const string& expectMessage = "")
-{
-    testRuleOnCode("input.cpp", rule, code, {}, violationIndex,
-        expectStartLine, expectStartColumn, expectEndLine, expectEndColumn, expectMessage);
-}
+    const string& expectMessage = "");
 
-inline void testRuleOnCXX11Code(RuleBase *rule,
+void testRuleOnCXX11Code(RuleBase *rule,
     const string &code,
     int violationIndex,
     int expectStartLine,
     int expectStartColumn,
     int expectEndLine,
     int expectEndColumn,
-    const string& expectMessage = "")
-{
-    testRuleOnCode("input.cpp", rule, code, {"-std=c++11"}, violationIndex,
-        expectStartLine, expectStartColumn, expectEndLine, expectEndColumn, expectMessage);
-}
+    const string& expectMessage = "");
 
-inline void testRuleOnObjCCode(RuleBase *rule,
+void testRuleOnObjCCode(RuleBase *rule,
     const string &code,
     int violationIndex,
     int expectStartLine,
     int expectStartColumn,
     int expectEndLine,
     int expectEndColumn,
-    const string& expectMessage = "")
-{
-    testRuleOnCode("input.m", rule, code, {}, violationIndex,
-        expectStartLine, expectStartColumn, expectEndLine, expectEndColumn, expectMessage);
-}
+    const string& expectMessage = "");
 
 #define VIOLATION_START "/*VIOLATION_START*/"
 #define VIOLATION_END "/*VIOLATION_END*/"
@@ -131,122 +84,27 @@ inline void testRuleOnObjCCode(RuleBase *rule,
 #define V_START VIOLATION_START
 #define V_END VIOLATION_END
 
-inline void ComputeLocalisation(const std::string& code, size_t offset, int* line, int* column)
-{
-    int currentColumn = 1;
-    int currentLine = 1;
-
-    for (size_t i = 0; i != offset; ++i)
-    {
-        if (code[i] == '\n')
-        {
-            currentColumn = 1;
-            ++currentLine;
-        }
-        else
-        {
-            ++currentColumn;
-        }
-    }
-    *line = currentLine;
-    *column = currentColumn;
-}
+void ComputeLocalisation(const std::string& code, size_t offset, int* line, int* column);
 
 // {start/end offset} ordered by increasing start-location then end-location.
-inline std::vector<std::pair<size_t, size_t>> extractViolationLocations(std::string& code)
-{
-    size_t findOffset = 0;
-    std::vector<size_t> startOffsets;
-    std::vector<std::pair<size_t,size_t>> rangeOffsets;
+ std::vector<std::pair<size_t, size_t>> extractViolationLocations(std::string& code);
 
-    for (;;)
-    {
-        const size_t startOffset = code.find(VIOLATION_START, findOffset);
-        const size_t endOffset = code.find(VIOLATION_END, findOffset);
-        if (startOffset == std::string::npos && endOffset == std::string::npos)
-        {
-            assert(startOffsets.empty());
-            std::sort(rangeOffsets.begin(), rangeOffsets.end());
-            return rangeOffsets;
-        }
-        if (startOffset < endOffset)
-        {
-            code.erase(startOffset, strlen(VIOLATION_START));
-            startOffsets.push_back(startOffset);
-            findOffset = startOffset;
-        }
-        else
-        {
-            code.erase(endOffset, strlen(VIOLATION_END));
-            assert(!startOffsets.empty());
-            rangeOffsets.push_back({startOffsets.back(), endOffset});
-            startOffsets.pop_back();
-            findOffset = endOffset;
-        }
-    }
-}
+bool lessByLocation(const Violation& lhs, const Violation& rhs);
 
-bool lessByLocation(const Violation& lhs, const Violation& rhs)
-{
-    if (lhs.startLine != rhs.startLine) return lhs.startLine < rhs.startLine;
-    if (lhs.startColumn != rhs.startColumn) return lhs.startColumn < rhs.startColumn;
-    if (lhs.endLine != rhs.endLine) return lhs.endLine < rhs.endLine;
-    if (lhs.endColumn != rhs.endColumn) return lhs.endColumn < rhs.endColumn;
-    return lhs.message < rhs.message;
-}
-
-inline void testRuleOnCode(const Twine& filename,
+void testRuleOnCode(const Twine& filename,
     const std::vector<std::string>& args,
     RuleBase* rule,
     std::string code,
-    const std::vector<std::string>& messages)
-{
-    const auto& rangeOffsets = extractViolationLocations(code);
-    ViolationSet violationSet;
+    const std::vector<std::string>& messages);
 
-    if (!computeViolationSet(filename, rule, code, args, &violationSet))
-    {
-        FAIL();
-        return;
-    }
-    vector<Violation> violations = violationSet.getViolations();
+void testRuleOnCode(RuleBase* rule, std::string code,
+    const std::vector<std::string>& messages = {});
 
-    ASSERT_THAT(violations.size(), Eq(rangeOffsets.size()));
+void testRuleOnCXXCode(RuleBase* rule, std::string code,
+    const std::vector<std::string>& messages = {});
 
-    std::sort(violations.begin(), violations.end(), &lessByLocation);
-    for (size_t i = 0; i != rangeOffsets.size(); ++i)
-    {
-        const Violation& violation = violations[i];
-        const size_t startOffset = rangeOffsets[i].first;
-        const size_t endOffset = rangeOffsets[i].second;
-        const std::string& message = i < messages.size() ? messages[i] : "";
-        int startLine, startColumn, endLine, endColumn;
-        ComputeLocalisation(code, startOffset, &startLine, &startColumn);
-        ComputeLocalisation(code, endOffset, &endLine, &endColumn);
-        validateViolation(violation, startLine, startColumn, endLine, endColumn, message);
-    }
-}
+void testRuleOnCXX11Code(RuleBase* rule, std::string code,
+    const std::vector<std::string>& messages = {});
 
-inline void testRuleOnCode(RuleBase* rule, std::string code,
-    const std::vector<std::string>& messages = {})
-{
-    testRuleOnCode("input.c", {}, rule, code, messages);
-}
-
-inline void testRuleOnCXXCode(RuleBase* rule, std::string code,
-    const std::vector<std::string>& messages = {})
-{
-    testRuleOnCode("input.cpp", {}, rule, code, messages);
-}
-
-inline void testRuleOnCXX11Code(RuleBase* rule, std::string code,
-    const std::vector<std::string>& messages = {})
-{
-    testRuleOnCode("input.cpp", {"-std=c++11"}, rule, code, messages);
-}
-
-inline void testRuleOnObjCCode(RuleBase* rule, std::string code,
-    const std::vector<std::string>& messages = {})
-{
-    testRuleOnCode("input.m", {}, rule, code, messages);
-}
+void testRuleOnObjCCode(RuleBase* rule, std::string code,
+    const std::vector<std::string>& messages = {});

--- a/oclint-scripts/travis
+++ b/oclint-scripts/travis
@@ -3,4 +3,10 @@
 ./clang prebuilt
 ./googleTest co
 ./googleTest build
-./test
+MODULE="$1"
+shift
+for dep in $*
+do
+    ./test "$dep"
+done
+./test "$MODULE"


### PR DESCRIPTION
This PR aims to improve build times and the usefulness of the build.

* ~~Split the build into multiple modules~~
* ~~Split header files into source and header~~
* Only include what is actually needed for each test file
* Merge oclint-rules test files into one or a few executables
* Do not rerun tests of the dependencies of every module

Caching for osx and trusty builds is only enabled for private repositories.
Is seems like the osx machines only have one core, despite travis claiming otherwise. Not much we can do about that.