### PR TITLE
Use the same dir for tests and normal builds

### DIFF
--- a/oclint-scripts/oclintscripts/path.py
+++ b/oclint-scripts/oclintscripts/path.py
@@ -20,9 +20,6 @@ def module_build_dir(module_name):
 def oclint_module_build_dir(module_name):
     return module_build_dir("oclint-" + module_name)
 
-def oclint_module_test_dir(module_name):
-    return module_build_dir("oclint-" + module_name + "-test")
-
 def oclint_module_dogfooding_dir(module_name):
     return module_build_dir("oclint-" + module_name + "-dogfooding")
 
@@ -51,11 +48,6 @@ class build:
     driver_build_dir = oclint_module_build_dir("driver")
 
     bundle_dir = oclint_module_build_dir("release")
-
-    core_test_dir = oclint_module_test_dir("core")
-    metrics_test_dir = oclint_module_test_dir("metrics")
-    rules_test_dir = oclint_module_test_dir("rules")
-    reporters_test_dir = oclint_module_test_dir("reporters")
 
     core_dogfooding_dir = oclint_module_dogfooding_dir("core")
     metrics_dogfooding_dir = oclint_module_dogfooding_dir("metrics")

--- a/oclint-scripts/test
+++ b/oclint-scripts/test
@@ -22,7 +22,7 @@ arg_parser.add_argument('-use-system-compiler', '--use-system-compiler', action=
 args = arg_parser.parse_args()
 
 def clean_module(module_name):
-    test_path = path.oclint_module_test_dir(module_name)
+    test_path = path.oclint_module_build_dir(module_name)
     path.rm_f(test_path);
 
 def build_command(module_extras, source_path):
@@ -34,7 +34,7 @@ def build_command(module_extras, source_path):
     return cmd_build.append_dict(extras).str()
 
 def test_result_path(module_name):
-    return os.path.join(path.oclint_module_test_dir(module_name), 'testresults.txt')
+    return os.path.join(path.oclint_module_build_dir(module_name), 'testresults.txt')
 
 def display_test_result(module_name):
     testresult_path = test_result_path(module_name)
@@ -42,16 +42,16 @@ def display_test_result(module_name):
         print(testresult_file.read())
 
 def test_module(module_name, multiple_thread):
-    build_path = path.oclint_module_test_dir(module_name)
+    build_path = path.oclint_module_build_dir(module_name)
     source_path = path.oclint_module_source_dir(module_name)
 
     module_extras = {}
     if module_name == "rules" or module_name == "reporters":
         module_extras['OCLINT_SOURCE_DIR'] = path.source.core_dir
-        module_extras['OCLINT_BUILD_DIR'] = path.build.core_test_dir
+        module_extras['OCLINT_BUILD_DIR'] = path.build.core_build_dir
     if module_name == "rules":
         module_extras['OCLINT_METRICS_SOURCE_DIR'] = path.source.metrics_dir
-        module_extras['OCLINT_METRICS_BUILD_DIR'] = path.build.metrics_test_dir
+        module_extras['OCLINT_METRICS_BUILD_DIR'] = path.build.metrics_build_dir
 
     command = build_command(module_extras, source_path)
 

--- a/oclint-scripts/travis
+++ b/oclint-scripts/travis
@@ -13,7 +13,7 @@ else
     shift
     for dep in $*
     do
-        ./test "$dep"
+        ./build "$dep"
     done
     ./test "$MODULE"
 fi


### PR DESCRIPTION
This enables us to simply build the dependencies without tests and then
just run the tests for the module we want to test.

I am not sure if this actually reduces the total time spend in the CI tests, but at least this way we dont run the tests for the dependencies multiple times.

I am not sure why the tests are build in a different directory. Is there some script that requires this?