### PR TITLE
Fix DiagnosticConsumer memory leak

### DIFF
--- a/oclint-driver/lib/Driver.cpp
+++ b/oclint-driver/lib/Driver.cpp
@@ -177,7 +177,7 @@ static clang::CompilerInvocation *newCompilerInvocation(std::string &mainExecuta
         llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs>(new clang::DiagnosticIDs()),
         &*diagOpts,
         new clang::DiagnosticConsumer(),
-        false);
+        true);
 
     // create driver
     const char *const mainBinaryPath = argv[0];


### PR DESCRIPTION
The DiagnosticConsumer gets allocated with new but is never deleted. The
engine is explicitly told to not take ownership of the consumer. This
would make sense if the consumer is later freed by oclint, but this
never happens. Instead we should just let the engine take ownership of
the client so that it gets deleted alongside the enngine.

This might be related to #275