### PR TITLE
Update to LLVM 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 language: cpp
 sudo: required
 dist: trusty
-osx_image: xcode7.2
+osx_image: xcode7.3
 before_install:
 - if [ $TRAVIS_OS_NAME == osx ]; then
     brew update;

--- a/oclint-core/cmake/OCLintConfig.cmake
+++ b/oclint-core/cmake/OCLintConfig.cmake
@@ -13,7 +13,6 @@ SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_CXX_LINKER_FLAGS} -fno-rtti")
 
 IF(APPLE)
     SET(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++ ${CMAKE_CXX_FLAGS}")
-    INCLUDE_DIRECTORIES(${OSX_DEVELOPER_ROOT}/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1)
 ELSEIF(MINGW)
     SET(CMAKE_CXX_FLAGS "-std=gnu++11 ${CMAKE_CXX_FLAGS}")
 ELSE()

--- a/oclint-driver/lib/Driver.cpp
+++ b/oclint-driver/lib/Driver.cpp
@@ -243,13 +243,14 @@ static void printCompileCommandDebugInfo(
 }
 #endif
 
-static std::vector<std::string> adjustArguments(std::vector<std::string> &unadjustedCmdLine)
+static std::vector<std::string> adjustArguments(std::vector<std::string> &unadjustedCmdLine,
+	const std::string& filename)
 {
     clang::tooling::ArgumentsAdjuster argAdjuster =
         clang::tooling::combineAdjusters(
             clang::tooling::getClangStripOutputAdjuster(),
             clang::tooling::getClangSyntaxOnlyAdjuster());
-    return argAdjuster(unadjustedCmdLine);
+    return argAdjuster(unadjustedCmdLine, filename);
 }
 
 static void constructCompilersAndFileManagers(std::vector<oclint::CompilerInstance *> &compilers,
@@ -260,7 +261,7 @@ static void constructCompilersAndFileManagers(std::vector<oclint::CompilerInstan
     for (auto &compileCommand : compileCommands)
     {
         std::vector<std::string> adjustedCmdLine =
-            adjustArguments(compileCommand.second.CommandLine);
+            adjustArguments(compileCommand.second.CommandLine, compileCommand.first);
 
 #ifndef NDEBUG
         printCompileCommandDebugInfo(compileCommand, adjustedCmdLine);
@@ -309,7 +310,7 @@ static void invokeClangStaticAnalyzer(
                 "please make sure the directory exists and you have permission to access!");
         }
         std::vector<std::string> adjustedArguments =
-            adjustArguments(compileCommand.second.CommandLine);
+            adjustArguments(compileCommand.second.CommandLine, compileCommand.first);
         clang::CompilerInvocation *compilerInvocation =
             newCompilerInvocation(mainExecutable, adjustedArguments, true);
         clang::FileManager *fileManager = newFileManager();

--- a/oclint-rules/lib/helper/SuppressHelper.cpp
+++ b/oclint-rules/lib/helper/SuppressHelper.cpp
@@ -29,8 +29,8 @@ bool markedParentsAsSuppress(const T &node, clang::ASTContext &context, oclint::
         return false;
     }
 
-    clang::ast_type_traits::DynTypedNode dynTypedNode = parents.front();
-    const clang::Decl *aDecl = dynTypedNode.get<clang::Decl>();
+    const clang::ast_type_traits::DynTypedNode* dynTypedNode = parents.begin();
+    const clang::Decl *aDecl = dynTypedNode->get<clang::Decl>();
     if (aDecl)
     {
         if (markedAsSuppress(aDecl, rule))
@@ -39,7 +39,7 @@ bool markedParentsAsSuppress(const T &node, clang::ASTContext &context, oclint::
         }
         return markedParentsAsSuppress(*aDecl, context, rule);
     }
-    const clang::Stmt *aStmt = dynTypedNode.get<clang::Stmt>();
+    const clang::Stmt *aStmt = dynTypedNode->get<clang::Stmt>();
     if (aStmt)
     {
         return markedParentsAsSuppress(*aStmt, context, rule);

--- a/oclint-rules/rules/design/AvoidDefaultArgumentsOnVirtualMethodsRule.cpp
+++ b/oclint-rules/rules/design/AvoidDefaultArgumentsOnVirtualMethodsRule.cpp
@@ -47,7 +47,7 @@ public:
     virtual void setUpMatcher() override
     {
         addMatcher(
-            methodDecl(isVirtual(), hasAnyParameter(hasDefaultArg()))
+            cxxMethodDecl(isVirtual(), hasAnyParameter(hasDefaultArg()))
             .bind("cxxMethod"));
     }
 };

--- a/oclint-rules/rules/design/AvoidPrivateStaticMembersRule.cpp
+++ b/oclint-rules/rules/design/AvoidPrivateStaticMembersRule.cpp
@@ -53,7 +53,7 @@ public:
     virtual void setUpMatcher() override
     {
         addMatcher(varDecl(isPrivate(), isStaticDataMember()).bind("field"));
-        addMatcher(methodDecl(isPrivate(), isStatic()).bind("cxxMethod"));
+        addMatcher(cxxMethodDecl(isPrivate(), isStatic()).bind("cxxMethod"));
     }
 };
 

--- a/oclint-scripts/oclintscripts/path.py
+++ b/oclint-scripts/oclintscripts/path.py
@@ -65,7 +65,7 @@ class url:
     xcodebuild = 'https://github.com/oclint/oclint-xcodebuild.git'
 
     clang_prebuilt_binary_for_darwin = 'http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz'
-    clang_prebuilt_binary_for_ubuntu_lts = 'http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz'
+    clang_prebuilt_binary_for_ubuntu_lts = 'http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz'
 
 def cd(dir_path):
     os.chdir(dir_path)

--- a/oclint-scripts/oclintscripts/path.py
+++ b/oclint-scripts/oclintscripts/path.py
@@ -64,8 +64,8 @@ class url:
     json_compilation_database = 'https://github.com/oclint/oclint-json-compilation-database.git'
     xcodebuild = 'https://github.com/oclint/oclint-xcodebuild.git'
 
-    clang_prebuilt_binary_for_darwin = 'http://llvm.org/releases/3.7.0/clang+llvm-3.7.0-x86_64-apple-darwin.tar.xz'
-    clang_prebuilt_binary_for_ubuntu_lts = 'http://llvm.org/releases/3.7.0/clang+llvm-3.7.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz'
+    clang_prebuilt_binary_for_darwin = 'http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz'
+    clang_prebuilt_binary_for_ubuntu_lts = 'http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz'
 
 def cd(dir_path):
     os.chdir(dir_path)

--- a/oclint-scripts/oclintscripts/version.py
+++ b/oclint-scripts/oclintscripts/version.py
@@ -20,4 +20,4 @@ def llvm_branches():
     return ['trunk', llvm_default_branch()]
 
 def llvm_default_branch():
-    return 'tags/RELEASE_371/final'
+    return 'tags/RELEASE_380/final'


### PR DESCRIPTION
I don't know if it was planned, but I needed it, so I did it ^^

The prebuilt LLVM packages url and the LLVM svn tag have been updated. I also updated the Ubuntu package url to 16.04 LTS (was 14.04).

A quick test on a project full of errors did not raise any obvious bug, but it will need more testing before being merged.

Let me know if I forgot anything.

EDIT: Your CI Glibc seems too old to pass the build, that's odd... Is Debian not up to date enough or do you need to update?