### PR TITLE
Fix memory leak in CompilerInstance

### DIFF
--- a/oclint-driver/include/oclint/CompilerInstance.h
+++ b/oclint-driver/include/oclint/CompilerInstance.h
@@ -20,7 +20,7 @@ public:
     void end();
 
 private:
-    std::vector<clang::FrontendAction *> _actions;
+    std::vector<std::unique_ptr<clang::FrontendAction>> _actions;
 };
 
 } // end namespace oclint

--- a/oclint-driver/lib/CompilerInstance.cpp
+++ b/oclint-driver/lib/CompilerInstance.cpp
@@ -87,7 +87,7 @@ void CompilerInstance::start()
         clang::FrontendAction *frontendAction = getFrontendAction();
         frontendAction->BeginSourceFile(*this, input);
         frontendAction->Execute();
-        _actions.push_back(frontendAction);
+        _actions.emplace_back(frontendAction);
     }
 }
 


### PR DESCRIPTION
The FrontendAction stored in the _actions vector was never deleted.
The unique_ptr now takes care of this.