### PR TITLE
Fix segfault in NPathComplexityMetric

### DIFF
--- a/oclint-metrics/include/oclint/metric/NPathComplexityMetric.h
+++ b/oclint-metrics/include/oclint/metric/NPathComplexityMetric.h
@@ -28,6 +28,7 @@ public:
             DISPATH(clang::DoStmt);
             DISPATH(clang::ForStmt);
             DISPATH(clang::SwitchStmt);
+            DISPATH(clang::SwitchCase);
             DISPATH(clang::ObjCForCollectionStmt);
         }
         return 1;
@@ -52,6 +53,7 @@ public:
     int nPath(clang::ForStmt *stmt);
     int nPath(clang::ObjCForCollectionStmt *stmt);
     int nPath(clang::SwitchStmt *stmt);
+    int nPath(clang::SwitchCase *stmt);
     int nPath(clang::ConditionalOperator *expr);
     int nPath(clang::BinaryOperator *expr);
     int nPath(clang::ParenExpr *expr);

--- a/oclint-metrics/test/NPathComplexityMetricTest.cpp
+++ b/oclint-metrics/test/NPathComplexityMetricTest.cpp
@@ -240,6 +240,15 @@ TEST(NPathComplexityMetricTest, SwitchStmtWithSimpleConditionAndOneCase)
     testMatcherOnCode(finder, "void mthd() { int i; switch (i) { case 1: break; } }");
 }
 
+TEST(NPathComplexityMetricTest, SwitchStmtWithSimpleConditionAndOneReturn)
+{
+    NPathCallback nPathCallback(1);
+    MatchFinder finder;
+    finder.addMatcher(functionDeclMatcher, &nPathCallback);
+
+    testMatcherOnCode(finder, "void mthd() { int i; switch (i) return; }");
+}
+
 TEST(NPathComplexityMetricTest, SwitchStmtWithSimpleConditionAndOneCaseOneDefault)
 {
     NPathCallback nPathCallback(2);


### PR DESCRIPTION
The nPath method for SwitchStmt casts the body to CompoundStmt. A switch
statement can also contain just a single case like this:
switch(arg)
   case3: return 2;

Here the body is actually just a single SwitchStmt. We have to check the
actual type of the body before casting it to CompoundStmt and
potentially triggering UB.

This should address #323, but needs a test that covers the new branch.