### PR TITLE
Show test failures

### DIFF
--- a/oclint-scripts/test
+++ b/oclint-scripts/test
@@ -65,7 +65,7 @@ def test_module(module_name, multiple_thread):
     process.call('make -j ' + multiple_thread)
     if not args.as_dep:
         run_ctest_command = 'ctest --output-on-failure > ' + test_result_path(module_name)
-        process.call(run_ctest_command)
+        subprocess.call(run_ctest_command, shell=True)
         display_test_result(module_name)
     path.cd(current_dir)
 


### PR DESCRIPTION
The 'call' helper function in oclintscripts call sys.exit if the
subprocess exits with a non-zero exit code. This prevented the test
script from printing out the ctest output after a failed test.