### PR TITLE
use LLVM outs for printing OCLint version

### DIFF
--- a/oclint-driver/main.cpp
+++ b/oclint-driver/main.cpp
@@ -151,9 +151,9 @@ int prepare()
 
 static void oclintVersionPrinter()
 {
-    cout << "OCLint (http://oclint.org/):\n";
-    cout << "  OCLint version " << oclint::Version::identifier() << ".\n";
-    cout << "  Built " << __DATE__ << " (" << __TIME__ << ").\n";
+    outs() << "OCLint (http://oclint.org/):\n";
+    outs() << "  OCLint version " << oclint::Version::identifier() << ".\n";
+    outs() << "  Built " << __DATE__ << " (" << __TIME__ << ").\n";
 }
 
 extern llvm::cl::OptionCategory OCLintOptionCategory;


### PR DESCRIPTION
LLVM's code for printing the version uses it's `outs()` stream instead
of `cout`. OCLint was using `cout` which doesn't always flush correctly
before the program exits. In particular, when using bash pipes or
redirects.

Tested it by running `../build/oclint-driver/bin/oclint-0.10.4
--version`