### PR TITLE
Revise metadata of some rules

### DIFF
--- a/oclint-driver/main_docgen.cpp
+++ b/oclint-driver/main_docgen.cpp
@@ -125,6 +125,8 @@ void writeRuleToCategory(ofstream& out, oclint::RuleBase* rule)
 
     out << "**Since: " << rule->since() << "**" << endl << endl;
 
+    out << "**Name: " << rule->name() << "**" << endl << endl;
+
     out << rule->description() << endl << endl;
 
     out << "This rule is defined by the following class: "

--- a/oclint-rules/rules/basic/MisplacedNullCheckRule.cpp
+++ b/oclint-rules/rules/basic/MisplacedNullCheckRule.cpp
@@ -87,7 +87,7 @@ public:
     virtual const std::string description() const override
     {
         return "The null check is misplaced. "
-            "In C and C++, sending a message to a null pointer could crash the app. "
+            "In C and C++, sending a message to a null pointer could crash the program. "
             "When null is misplaced, either the check is useless or it's incorrect.";
     }
 
@@ -158,6 +158,11 @@ public:
         return "The nil check is misplaced. "
             "In Objective-C, sending a message to a nil pointer simply does nothing. "
             "But code readers may be confused about the misplaced nil check.";
+    }
+
+    virtual const std::string fileName() const override
+    {
+        return "MisplacedNullCheckRule.cpp";
     }
 
     virtual const std::string example() const override

--- a/oclint-rules/rules/basic/ReturnFromFinallyBlockRule.cpp
+++ b/oclint-rules/rules/basic/ReturnFromFinallyBlockRule.cpp
@@ -50,7 +50,7 @@ public:
 
     virtual const std::string description() const override
     {
-        return "Returning from a finally block is not recommended.";
+        return "Returning from a ``finally`` block is not recommended.";
     }
 
     virtual const std::string example() const override

--- a/oclint-rules/rules/cocoa/ObjCVerifyIsEqualHashRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyIsEqualHashRule.cpp
@@ -15,7 +15,7 @@ class ObjCVerifyIsEqualHashRule : public AbstractASTVisitorRule<ObjCVerifyIsEqua
 public:
     virtual const string name() const override
     {
-        return "must override hash with isEqual";
+        return "missing hash method";
     }
 
     virtual int priority() const override

--- a/oclint-rules/rules/cocoa/ObjCVerifyMustCallSuperRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyMustCallSuperRule.cpp
@@ -59,7 +59,7 @@ private:
 public:
     virtual const string name() const override
     {
-        return "missing calling base method";
+        return "missing call to base method";
     }
 
     virtual const string attributeName() const override

--- a/oclint-rules/rules/cocoa/ObjCVerifyMustCallSuperRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyMustCallSuperRule.cpp
@@ -59,7 +59,12 @@ private:
 public:
     virtual const string name() const override
     {
-        return "must call super";
+        return "missing calling base method";
+    }
+
+    virtual const string attributeName() const override
+    {
+        return "base method";
     }
 
     virtual int priority() const override
@@ -86,7 +91,7 @@ public:
     virtual const std::string description() const override
     {
         return "When a method is declared with "
-            "``__attribute__((annotate(\"oclint:enforce[must call super]\")))`` annotation, "
+            "``__attribute__((annotate(\"oclint:enforce[base method]\")))`` annotation, "
             "all of its implementations (including its own and its sub classes) "
             "must call the method implementation in super class.";
     }
@@ -102,7 +107,7 @@ public:
 .. code-block:: objective-c
 
     @interface UIView (OCLintStaticChecks)
-    - (void)layoutSubviews __attribute__((annotate("oclint:enforce[must call super]")));
+    - (void)layoutSubviews __attribute__((annotate("oclint:enforce[base method]")));
     @end
 
     @interface CustomView : UIView

--- a/oclint-rules/rules/cocoa/ObjCVerifyProhibitedCallRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyProhibitedCallRule.cpp
@@ -40,12 +40,12 @@ public:
 
     virtual const string name() const override
     {
-        return "verify prohibited call";
+        return "calling prohibited method";
     }
 
     virtual const string attributeName() const override
     {
-        return "prohibited call";
+        return "prohibited method";
     }
 
     virtual int priority() const override
@@ -67,7 +67,7 @@ public:
     virtual const std::string description() const override
     {
          return "When a method is declared with "
-            "``__attribute__((annotate(\"oclint:enforce[prohibited call]\")))`` "
+            "``__attribute__((annotate(\"oclint:enforce[prohibited method]\")))`` "
             "annotation, all of its usages will be prohibited.";
     }
 
@@ -82,7 +82,7 @@ public:
 .. code-block:: objective-c
 
     @interface A : NSObject
-    - (void)foo __attribute__((annotate("oclint:enforce[prohibited call]")));
+    - (void)foo __attribute__((annotate("oclint:enforce[prohibited method]")));
     @end
 
     @implementation A

--- a/oclint-rules/rules/cocoa/ObjCVerifyProtectedMethodRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyProtectedMethodRule.cpp
@@ -71,7 +71,7 @@ public:
 
     virtual const string name() const override
     {
-        return "verify protected method";
+        return "calling protected method";
     }
 
     virtual const string attributeName() const override

--- a/oclint-rules/rules/cocoa/ObjCVerifySubclassMustImplementRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifySubclassMustImplementRule.cpp
@@ -16,7 +16,12 @@ class ObjCVerifySubclassMustImplementRule : public
 public:
     virtual const string name() const override
     {
-        return "subclass must implement";
+        return "missing abstract method implementation";
+    }
+
+    virtual const string attributeName() const override
+    {
+        return "abstract method";
     }
 
     virtual int priority() const override
@@ -42,7 +47,7 @@ public:
 
     virtual const std::string description() const override
     {
-        return "Due to the Objective-C language tries to postpone making decisions "
+        return "Due to the Objective-C language tries to postpone the decision makings "
             "to the runtime as much as possible, an abstract method is okay to be declared "
             "but without implementations. This rule tries to verify the subclass implement "
             "the correct abstract method.";
@@ -60,7 +65,7 @@ public:
 
     @interface Parent
 
-    - (void)anAbstractMethod __attribute__((annotate("oclint:enforce[subclass must implement]")));
+    - (void)anAbstractMethod __attribute__((annotate("oclint:enforce[abstract method]")));
 
     @end
 

--- a/oclint-rules/rules/convention/BaseClassDestructorShouldBeVirtualOrProtectedRule.cpp
+++ b/oclint-rules/rules/convention/BaseClassDestructorShouldBeVirtualOrProtectedRule.cpp
@@ -41,6 +41,11 @@ public:
         return "base class destructor should be virtual or protected";
     }
 
+    virtual const std::string identifier() const override
+    {
+        return "ProblematicBaseClassDestructor";
+    }
+
     virtual int priority() const override
     {
         return 2;
@@ -64,7 +69,12 @@ public:
 
     virtual const std::string description() const override
     {
-        return "Make base class destructors public and virtual, or protected and nonvirtual";
+        return "Make base class destructor public and virtual, or protected and nonvirtual";
+    }
+
+    virtual const std::string fileName() const override
+    {
+        return "BaseClassDestructorShouldBeVirtualOrProtectedRule.cpp";
     }
 
     virtual const std::string example() const override

--- a/oclint-rules/rules/convention/CoveredSwitchStatementsDontNeedDefaultRule.cpp
+++ b/oclint-rules/rules/convention/CoveredSwitchStatementsDontNeedDefaultRule.cpp
@@ -11,7 +11,12 @@ class CoveredSwitchStatementsDontNeedDefaultRule :
 public:
     virtual const string name() const override
     {
-        return "covered switch statements dont need default";
+        return "unnecessary default statement in covered switch statement";
+    }
+
+    virtual const string identifier() const override
+    {
+        return "UnnecessaryDefaultStatement";
     }
 
     virtual int priority() const override
@@ -36,6 +41,11 @@ public:
             "a default label is not needed and should be removed. "
             "If the switch is not fully covered, "
             "the SwitchStatementsShouldHaveDefault rule will report.";
+    }
+
+    virtual const std::string fileName() const override
+    {
+        return "CoveredSwitchStatementsDontNeedDefaultRule.cpp";
     }
 
     virtual const std::string example() const override

--- a/oclint-rules/rules/convention/DefaultLabelNotLastInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/DefaultLabelNotLastInSwitchStatementRule.cpp
@@ -11,7 +11,12 @@ class DefaultLabelNotLastInSwitchStatementRule :
 public:
     virtual const string name() const override
     {
-        return "default label not last in switch statement";
+        return "ill-placed default label in switch statement";
+    }
+
+    virtual const string identifier() const override
+    {
+        return "IllplacedDefaultLabel";
     }
 
     virtual int priority() const override
@@ -34,6 +39,11 @@ public:
     {
         return "It is very confusing when default label is not the last label "
             "in a switch statement.";
+    }
+
+    virtual const std::string fileName() const override
+    {
+        return "DefaultLabelNotLastInSwitchStatementRule.cpp";
     }
 
     virtual const std::string example() const override

--- a/oclint-rules/rules/convention/DefaultLabelNotLastInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/DefaultLabelNotLastInSwitchStatementRule.cpp
@@ -16,7 +16,7 @@ public:
 
     virtual const string identifier() const override
     {
-        return "IllplacedDefaultLabel";
+        return "MisplacedDefaultLabel";
     }
 
     virtual int priority() const override

--- a/oclint-rules/rules/convention/ObjCAssignIvarOutsideAccessorsRule.cpp
+++ b/oclint-rules/rules/convention/ObjCAssignIvarOutsideAccessorsRule.cpp
@@ -72,6 +72,11 @@ public:
         return "ivar assignment outside accessors or init";
     }
 
+    virtual const string identifier() const override
+    {
+        return "AssignIvarOutsideAccessors";
+    }
+
     virtual int priority() const override
     {
         return 2;

--- a/oclint-rules/rules/convention/PreferEarlyExitRule.cpp
+++ b/oclint-rules/rules/convention/PreferEarlyExitRule.cpp
@@ -67,7 +67,12 @@ private:
 public:
     virtual const string name() const override
     {
-        return "use early exits and continue";
+        return "prefer early exits and continue";
+    }
+
+    virtual const string identifier() const override
+    {
+        return "PreferEarlyExit";
     }
 
     virtual int priority() const override

--- a/oclint-rules/rules/convention/SwitchStatementsShouldHaveDefaultRule.cpp
+++ b/oclint-rules/rules/convention/SwitchStatementsShouldHaveDefaultRule.cpp
@@ -11,7 +11,12 @@ class SwitchStatementsShouldHaveDefaultRule :
 public:
     virtual const string name() const override
     {
-        return "switch statements should have default";
+        return "missing default in switch statements";
+    }
+
+    virtual const string identifier() const override
+    {
+        return "MissingDefaultStatement";
     }
 
     virtual int priority() const override
@@ -33,6 +38,11 @@ public:
     virtual const std::string description() const override
     {
         return "Switch statements should have a default statement.";
+    }
+
+    virtual const std::string fileName() const override
+    {
+        return "SwitchStatementsShouldHaveDefaultRule.cpp";
     }
 
     virtual const std::string example() const override

--- a/oclint-rules/rules/migration/ObjCBoxedExpressionsRule.cpp
+++ b/oclint-rules/rules/migration/ObjCBoxedExpressionsRule.cpp
@@ -80,7 +80,7 @@ private:
 public:
     virtual const string name() const override
     {
-        return "replace with boxed expression";
+        return "use boxed expression";
     }
 
     virtual int priority() const override

--- a/oclint-rules/rules/migration/ObjCContainerLiteralsRule.cpp
+++ b/oclint-rules/rules/migration/ObjCContainerLiteralsRule.cpp
@@ -11,7 +11,7 @@ class ObjCContainerLiteralsRule : public AbstractASTVisitorRule<ObjCContainerLit
 public:
     virtual const string name() const override
     {
-        return "replace with container literal";
+        return "use container literal";
     }
 
     virtual int priority() const override

--- a/oclint-rules/rules/migration/ObjCNSNumberLiteralsRule.cpp
+++ b/oclint-rules/rules/migration/ObjCNSNumberLiteralsRule.cpp
@@ -74,7 +74,7 @@ private:
 public:
     virtual const string name() const override
     {
-        return "replace with number literal";
+        return "use number literal";
     }
 
     virtual int priority() const override

--- a/oclint-rules/rules/migration/ObjCObjectSubscriptingRule.cpp
+++ b/oclint-rules/rules/migration/ObjCObjectSubscriptingRule.cpp
@@ -52,7 +52,7 @@ private:
 public:
     virtual const string name() const override
     {
-        return "replace with object subscripting";
+        return "use object subscripting";
     }
 
     virtual int priority() const override

--- a/oclint-rules/test/cocoa/ObjCVerifyIsEqualHashRuleTest.cpp
+++ b/oclint-rules/test/cocoa/ObjCVerifyIsEqualHashRuleTest.cpp
@@ -71,7 +71,7 @@ TEST(ObjCVerifyIsEqualHashRuleTest, PropertyTest)
 {
     ObjCVerifyIsEqualHashRule rule;
     EXPECT_EQ(1, rule.priority());
-    EXPECT_EQ("must override hash with isEqual", rule.name());
+    EXPECT_EQ("missing hash method", rule.name());
     EXPECT_EQ("cocoa", rule.category());
 }
 

--- a/oclint-rules/test/cocoa/ObjCVerifyMustCallSuperRuleTest.cpp
+++ b/oclint-rules/test/cocoa/ObjCVerifyMustCallSuperRuleTest.cpp
@@ -34,7 +34,7 @@ typedef unsigned char BOOL;                                                     
 @interface SomeBaseClass : NSObject                                                            \n\
                                                                                                \n\
 - (void)viewWillAppear:(BOOL)animated                                                          \n\
-__attribute__((annotate(\"oclint:enforce[must call super]\")));                                \n\
+__attribute__((annotate(\"oclint:enforce[base method]\")));                                    \n\
                                                                                                \n\
 @end                                                                                           \n\
                                                                                                \n\
@@ -51,7 +51,7 @@ static const string testSuppression = "\
 @implementation ChildViewController                                             \n\
                                                                                 \n\
 - (void)viewWillAppear:(BOOL)animated                                           \n\
-    __attribute__((annotate(\"oclint:suppress[must call super]\"))) {           \n\
+    __attribute__((annotate(\"oclint:suppress[base method]\"))) {               \n\
 }                                                                               \n\
                                                                                 \n\
 @end                                                                            \n\
@@ -94,7 +94,7 @@ TEST(ObjcVerifyMustCallSuperRuleTest, PropertyTest)
 {
     ObjCVerifyMustCallSuperRule rule;
     EXPECT_EQ(1, rule.priority());
-    EXPECT_EQ("must call super", rule.name());
+    EXPECT_EQ("missing calling base method", rule.name());
     EXPECT_EQ("cocoa", rule.category());
 }
 

--- a/oclint-rules/test/cocoa/ObjCVerifyMustCallSuperRuleTest.cpp
+++ b/oclint-rules/test/cocoa/ObjCVerifyMustCallSuperRuleTest.cpp
@@ -94,7 +94,7 @@ TEST(ObjcVerifyMustCallSuperRuleTest, PropertyTest)
 {
     ObjCVerifyMustCallSuperRule rule;
     EXPECT_EQ(1, rule.priority());
-    EXPECT_EQ("missing calling base method", rule.name());
+    EXPECT_EQ("missing call to base method", rule.name());
     EXPECT_EQ("cocoa", rule.category());
 }
 

--- a/oclint-rules/test/cocoa/ObjCVerifyProhibitedCallRuleTest.cpp
+++ b/oclint-rules/test/cocoa/ObjCVerifyProhibitedCallRuleTest.cpp
@@ -8,7 +8,7 @@ string testBase = R"END(
 @end
 
 @interface A : NSObject
-- (void)foo __attribute__((annotate("oclint:enforce[prohibited call]")));
+- (void)foo __attribute__((annotate("oclint:enforce[prohibited method]")));
 @end
 
 @interface B : NSObject
@@ -22,7 +22,7 @@ TEST(ObjCVerifyProhibitedCallRule, PropertyTest)
 {
     ObjCVerifyProhibitedCallRule rule;
     EXPECT_EQ(1, rule.priority());
-    EXPECT_EQ("verify prohibited call", rule.name());
+    EXPECT_EQ("calling prohibited method", rule.name());
     EXPECT_EQ("cocoa", rule.category());
 }
 
@@ -97,7 +97,7 @@ TEST(ObjCVerifyProhibitedCallRule, ProtectedPropertyGetterOutside)
     const string testGetterOutside = testBase + R"END(
     @interface C : NSObject
     @property (strong) A* a
-        __attribute__((annotate("oclint:enforce[prohibited call]")));
+        __attribute__((annotate("oclint:enforce[prohibited method]")));
     @end
     @interface D : NSObject
     @property (strong) C* c;
@@ -119,7 +119,7 @@ TEST(ObjCVerifyProhibitedCallRule, ProtectedPropertySetterOutside)
     const string testSetterOutside = testBase + R"END(
     @interface C : NSObject
     @property (strong) A* a
-        __attribute__((annotate("oclint:enforce[prohibited call]")));
+        __attribute__((annotate("oclint:enforce[prohibited method]")));
     @end
     @interface D : NSObject
     @property (strong) C* c;
@@ -140,7 +140,7 @@ TEST(ObjCVerifyProhibitedCallRule, ProtectedPropertyGetterInside)
     const string testGetterInside = testBase + R"END(
     @interface C : NSObject
     @property (strong) A* a
-        __attribute__((annotate("oclint:enforce[prohibited call]")));
+        __attribute__((annotate("oclint:enforce[prohibited method]")));
     @end
     @interface D : C
     @property (strong) C* c;
@@ -159,7 +159,7 @@ TEST(ObjCVerifyProhibitedCallRule, ProtectedPropertySetterInside)
     const string testSetterInside = testBase + R"END(
     @interface C : NSObject
     @property (strong) A* a
-        __attribute__((annotate("oclint:enforce[prohibited call]")));
+        __attribute__((annotate("oclint:enforce[prohibited method]")));
     @end
     @interface D : C
     @property (strong) C* c;
@@ -228,7 +228,7 @@ TEST(ObjCVerifyProhibitedCallRule, PropertyCategoryOutside)
     @end
     @interface C (Additions)
     - (void)setA:(A*)a
-        __attribute__((annotate("oclint:enforce[prohibited call]")));
+        __attribute__((annotate("oclint:enforce[prohibited method]")));
     @end
     @interface D : NSObject
     @property (strong) C* c;
@@ -246,7 +246,7 @@ TEST(ObjCVerifyProhibitedCallRule, PropertyCategoryOutside)
 TEST(ObjCVerifyProhibitedCallRule, ProhibitedFunctionCall)
 {
     const string testFunction = R"END(
-    void foo(int x) __attribute__((annotate("oclint:enforce[prohibited call]")));
+    void foo(int x) __attribute__((annotate("oclint:enforce[prohibited method]")));
     int main(int argc, char* argv[]) {
         foo(3);
         return 0;
@@ -260,7 +260,7 @@ TEST(ObjCVerifyProhibitedCallRule, RedeclareFunctionCallBefore)
 {
     const string testFunction = R"END(
     void foo(int x);
-    void foo(int x) __attribute__((annotate("oclint:enforce[prohibited call]")));
+    void foo(int x) __attribute__((annotate("oclint:enforce[prohibited method]")));
     int main(int argc, char* argv[]) {
         foo(3);
         return 0;
@@ -273,7 +273,7 @@ TEST(ObjCVerifyProhibitedCallRule, RedeclareFunctionCallBefore)
 TEST(ObjCVerifyProhibitedCallRule, RedeclareFunctionCallAfter)
 {
     const string testFunction = R"END(
-    void foo(int x) __attribute__((annotate("oclint:enforce[prohibited call]")));
+    void foo(int x) __attribute__((annotate("oclint:enforce[prohibited method]")));
     void foo(int x);
     int main(int argc, char* argv[]) {
         foo(3);
@@ -287,7 +287,7 @@ TEST(ObjCVerifyProhibitedCallRule, RedeclareFunctionCallAfter)
 TEST(ObjCVerifyProhibitedCallRule, CommentFunction)
 {
     const string testFunction = R"END(
-    void foo(int x) __attribute__((annotate("oclint:enforce[prohibited call][bar]")));
+    void foo(int x) __attribute__((annotate("oclint:enforce[prohibited method][bar]")));
     int main(int argc, char* argv[]) {
         foo(3);
         return 0;
@@ -306,7 +306,7 @@ TEST(ObjCVerifyProhibitedCallRule, CommentMethod)
 
     @interface A : NSObject
 
-    - (void)foo __attribute__((annotate("oclint:enforce[prohibited call][bar]")));
+    - (void)foo __attribute__((annotate("oclint:enforce[prohibited method][bar]")));
 
     @end
     @interface B : NSObject
@@ -348,7 +348,7 @@ TEST(ObjCVerifyProhibitedCallRule, ProtocolAnnotation)
         typedef int SEL;
         @protocol NSObject
             - (int)respondsToSelector:(SEL)selector
-            __attribute__((annotate("oclint:enforce[prohibited call]")));
+            __attribute__((annotate("oclint:enforce[prohibited method]")));
         @end
         @interface NSObject <NSObject>
         @end

--- a/oclint-rules/test/cocoa/ObjCVerifyProtectedMethodRuleTest.cpp
+++ b/oclint-rules/test/cocoa/ObjCVerifyProtectedMethodRuleTest.cpp
@@ -23,7 +23,7 @@ TEST(ObjCVerifyProtectedMethodRule, PropertyTest)
 {
     ObjCVerifyProtectedMethodRule rule;
     EXPECT_EQ(1, rule.priority());
-    EXPECT_EQ("verify protected method", rule.name());
+    EXPECT_EQ("calling protected method", rule.name());
     EXPECT_EQ("protected method", rule.attributeName());
     EXPECT_EQ(LANG_OBJC, rule.supportedLanguages());
     EXPECT_EQ("cocoa", rule.category());

--- a/oclint-rules/test/cocoa/ObjCVerifySubclassMustImplementRuleTest.cpp
+++ b/oclint-rules/test/cocoa/ObjCVerifySubclassMustImplementRuleTest.cpp
@@ -7,7 +7,7 @@ static string testAnnotationBase = "\
 @interface Parent                                   \n\
                                                     \n\
 - (void)someAbstractMethod                          \n\
-    __attribute__((annotate(\"oclint:enforce[subclass must implement]\")));  \n\
+    __attribute__((annotate(\"oclint:enforce[abstract method]\")));  \n\
 @end                                                \n\
                                                     \n\
 @interface Child : Parent                           \n\
@@ -65,7 +65,7 @@ TEST(ObjcVerifySubclassMustImplementRuleTest, PropertyTest)
 {
     ObjCVerifySubclassMustImplementRule rule;
     EXPECT_EQ(1, rule.priority());
-    EXPECT_EQ("subclass must implement", rule.name());
+    EXPECT_EQ("missing abstract method implementation", rule.name());
     EXPECT_EQ("cocoa", rule.category());
 }
 

--- a/oclint-rules/test/convention/CoveredSwitchStatementsDontNeedDefaultRuleTest.cpp
+++ b/oclint-rules/test/convention/CoveredSwitchStatementsDontNeedDefaultRuleTest.cpp
@@ -6,7 +6,7 @@ TEST(CoveredSwitchStatementsDontNeedDefaultRuleTest, PropertyTest)
 {
     CoveredSwitchStatementsDontNeedDefaultRule rule;
     EXPECT_EQ(3, rule.priority());
-    EXPECT_EQ("covered switch statements dont need default", rule.name());
+    EXPECT_EQ("unnecessary default statement in covered switch statement", rule.name());
     EXPECT_EQ("convention", rule.category());
 }
 

--- a/oclint-rules/test/convention/DefaultLabelNotLastInSwitchStatementRuleTest.cpp
+++ b/oclint-rules/test/convention/DefaultLabelNotLastInSwitchStatementRuleTest.cpp
@@ -7,6 +7,7 @@ TEST(DefaultLabelNotLastInSwitchStatementRuleTest, PropertyTest)
     DefaultLabelNotLastInSwitchStatementRule rule;
     EXPECT_EQ(3, rule.priority());
     EXPECT_EQ("ill-placed default label in switch statement", rule.name());
+    EXPECT_EQ("MisplacedDefaultLabel", rule.identifier());
     EXPECT_EQ("convention", rule.category());
 }
 

--- a/oclint-rules/test/convention/DefaultLabelNotLastInSwitchStatementRuleTest.cpp
+++ b/oclint-rules/test/convention/DefaultLabelNotLastInSwitchStatementRuleTest.cpp
@@ -6,7 +6,7 @@ TEST(DefaultLabelNotLastInSwitchStatementRuleTest, PropertyTest)
 {
     DefaultLabelNotLastInSwitchStatementRule rule;
     EXPECT_EQ(3, rule.priority());
-    EXPECT_EQ("default label not last in switch statement", rule.name());
+    EXPECT_EQ("ill-placed default label in switch statement", rule.name());
     EXPECT_EQ("convention", rule.category());
 }
 

--- a/oclint-rules/test/convention/PreferEarlyExitRuleTest.cpp
+++ b/oclint-rules/test/convention/PreferEarlyExitRuleTest.cpp
@@ -103,7 +103,7 @@ TEST_F(PreferEarlyExitRuleTest, PropertyTest)
 {
     PreferEarlyExitRule rule;
     EXPECT_EQ(3, rule.priority());
-    EXPECT_EQ("use early exits and continue", rule.name());
+    EXPECT_EQ("prefer early exits and continue", rule.name());
     EXPECT_EQ("convention", rule.category());
 }
 

--- a/oclint-rules/test/convention/SwitchStatementsShouldHaveDefaultRuleTest.cpp
+++ b/oclint-rules/test/convention/SwitchStatementsShouldHaveDefaultRuleTest.cpp
@@ -6,7 +6,7 @@ TEST(SwitchStatementsShouldHaveDefaultRuleTest, PropertyTest)
 {
     SwitchStatementsShouldHaveDefaultRule rule;
     EXPECT_EQ(3, rule.priority());
-    EXPECT_EQ("switch statements should have default", rule.name());
+    EXPECT_EQ("missing default in switch statements", rule.name());
     EXPECT_EQ("convention", rule.category());
 }
 

--- a/oclint-rules/test/migration/ObjCBoxedExpressionsRuleTest.cpp
+++ b/oclint-rules/test/migration/ObjCBoxedExpressionsRuleTest.cpp
@@ -36,7 +36,7 @@ TEST(ObjCBoxedExpressionsRuleTest, PropertyTest)
 {
     ObjCBoxedExpressionsRule rule;
     EXPECT_EQ(3, rule.priority());
-    EXPECT_EQ("replace with boxed expression", rule.name());
+    EXPECT_EQ("use boxed expression", rule.name());
     EXPECT_EQ("migration", rule.category());
 }
 

--- a/oclint-rules/test/migration/ObjCContainerLiteralsRuleTest.cpp
+++ b/oclint-rules/test/migration/ObjCContainerLiteralsRuleTest.cpp
@@ -38,7 +38,7 @@ TEST(ObjCContainerLiteralsRuleTest, PropertyTest)
 {
     ObjCContainerLiteralsRule rule;
     EXPECT_EQ(3, rule.priority());
-    EXPECT_EQ("replace with container literal", rule.name());
+    EXPECT_EQ("use container literal", rule.name());
     EXPECT_EQ("migration", rule.category());
 }
 

--- a/oclint-rules/test/migration/ObjCNSNumberLiteralsRuleTest.cpp
+++ b/oclint-rules/test/migration/ObjCNSNumberLiteralsRuleTest.cpp
@@ -33,7 +33,7 @@ TEST(ObjCNSNumberLiteralsRuleTest, PropertyTest)
 {
     ObjCNSNumberLiteralsRule rule;
     EXPECT_EQ(3, rule.priority());
-    EXPECT_EQ("replace with number literal", rule.name());
+    EXPECT_EQ("use number literal", rule.name());
     EXPECT_EQ("migration", rule.category());
 }
 

--- a/oclint-rules/test/migration/ObjCObjectSubscriptingRuleTest.cpp
+++ b/oclint-rules/test/migration/ObjCObjectSubscriptingRuleTest.cpp
@@ -50,7 +50,7 @@ TEST(ObjCObjectSubscriptingRuleTest, PropertyTest)
 {
     ObjCObjectSubscriptingRule rule;
     EXPECT_EQ(3, rule.priority());
-    EXPECT_EQ("replace with object subscripting", rule.name());
+    EXPECT_EQ("use object subscripting", rule.name());
     EXPECT_EQ("migration", rule.category());
 }
 


### PR DESCRIPTION
Refining the metadata of rules is an on-going process. We recently hear some confusions among the rule name, identifier, and attribute name to be used. By following a sequence of rule changes, document enhancement, and automations, we revise the metadata of some of the rules. 

Improvements and suggestions are welcomed.

Identifier changes incorporated in this pull request:

- "MustOverrideHashWithIsEqual" to "MissingHashMethod"
- "MustCallSuper" to "MissingCallToBaseMethod"
- "VerifyProhibitedCall" to "CallingProhibitedMethod"
- "VerifyProtectedMethod" to "CallingProtectedMethod"
- "SubclassMustImplement" to "MissingAbstractMethodImplementation"
- "BaseClassDestructorShouldBeVirtualOrProtected" to "ProblematicBaseClassDestructor"
- "CoveredSwitchStatementsDontNeedDefault" to "UnnecessaryDefaultStatement"
- "DefaultLabelNotLastInSwitchStatement" to "MisplacedDefaultLabel"
- "IvarAssignmentOutsideAccessorsOrInit" to "AssignIvarOutsideAccessors"
- "UseEarlyExitsAndContinue" to "PreferEarlyExit"
- "SwitchStatementsShouldHaveDefault" to "MissingDefaultStatement"
- "ReplaceWithBoxedExpression" to "UseBoxedExpression"
- "ReplaceWithContainerLiteral" to "UseContainerLiteral"
- "ReplaceWithNumberLiteral" to "UseNumberLiteral"
- "ReplaceWithObjectSubscripting" to "UseObjectSubscripting"

Rule name changes incorporated in this pull request:

- "must override hash with isEqual" to "missing hash method"
- "must call super" to "missing call to base method"
- "verify prohibited call" to "calling prohibited method"
- "verify protected method" to "calling protected method"
- "subclass must implement" to "missing abstract method implementation"
- "covered switch statements dont need default" to "unnecessary default statement in covered switch statement"
- "default label not last in switch statement" to "ill-placed default label in switch statement"
- "use early exits and continue" to "prefer early exits and continue"
- "switch statements should have default" to "missing default in switch statements"
- "replace with boxed expression" to "use boxed expression"
- "replace with container literal" to "use container literal"
- "replace with number literal" to "use number literal"
- "replace with object subscripting" to "use object subscripting"

Attribute name changes incorporated in this pull request:

- "must call super" to "base method"
- "prohibited call" to "prohibited method"
- "subclass must implement" to "abstract method"

Coming document changes:

We will expose the details of rules more explicitly in our documentation as well:

![rule_doc_illustration](https://cloud.githubusercontent.com/assets/4386920/16782338/f5b2c2d6-4833-11e6-85c5-3e92eba8d2db.png)

