### PR TITLE
Return `src` for dev build from source code

### DIFF
--- a/oclint-scripts/oclintscripts/version.py
+++ b/oclint-scripts/oclintscripts/version.py
@@ -6,18 +6,21 @@ import os
 from oclintscripts import path
 from oclintscripts import environment
 
-def git_hash():
-    current_working_folder = os.getcwd()
-    os.chdir(path.root_dir)
-    git_hash = subprocess.check_output(['git', 'log', '-n', '1', '--pretty=%h']).split()[0]
-    path.cd(current_working_folder)
-    return git_hash
+def dev_version():
+    try:
+        current_working_folder = os.getcwd()
+        os.chdir(path.root_dir)
+        git_hash = subprocess.check_output(['git', 'log', '-n', '1', '--pretty=%h']).split()[0]
+        path.cd(current_working_folder)
+        return git_hash
+    except:
+        return "src"
 
 def oclint_version():
     return "0.10.4"
 
 def oclint_dev_version():
-    return oclint_version() + '.dev.' + git_hash()
+    return oclint_version() + '.dev.' + dev_version()
 
 def llvm_branches():
     return [llvm_master_branch(), llvm_latest_release_branch()]

--- a/oclint-scripts/oclintscripts/version.py
+++ b/oclint-scripts/oclintscripts/version.py
@@ -7,13 +7,15 @@ from oclintscripts import path
 from oclintscripts import environment
 
 def dev_version():
+    current_working_folder = os.getcwd()
     try:
-        current_working_folder = os.getcwd()
         os.chdir(path.root_dir)
         git_hash = subprocess.check_output(['git', 'log', '-n', '1', '--pretty=%h']).split()[0]
         path.cd(current_working_folder)
         return git_hash
     except:
+        print("Ignore the git error above if you are building from a source code download instead of a git clone.")
+        path.cd(current_working_folder)
         return "src"
 
 def oclint_version():


### PR DESCRIPTION
This pull request tries to fix the broken build script when oclint is downloaded from source code as compressed archives instead of as a git clone. 