### PR TITLE
Fix segfault if file does not exist

### DIFF
--- a/oclint-driver/lib/CompilerInstance.cpp
+++ b/oclint-driver/lib/CompilerInstance.cpp
@@ -85,9 +85,11 @@ void CompilerInstance::start()
         }
 
         clang::FrontendAction *frontendAction = getFrontendAction();
-        frontendAction->BeginSourceFile(*this, input);
-        frontendAction->Execute();
-        _actions.emplace_back(frontendAction);
+        if(frontendAction->BeginSourceFile(*this, input))
+        {
+            frontendAction->Execute();
+            _actions.emplace_back(frontendAction);
+        }
     }
 }
 


### PR DESCRIPTION
If FrontendAction::BeginSourceFile fails calling Execute causes
undefined behaviour. This can happen for example if the file does not
exist.

In such a case we should skip this file and move on to the next.

Fixes #353