### PR TITLE
Treat continue as a break in switch statement

### DIFF
--- a/oclint-rules/rules/convention/MissingBreakInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/MissingBreakInSwitchStatementRule.cpp
@@ -26,6 +26,11 @@ class MissingBreakInSwitchStatementRule :
             return false;
         }
 
+        bool VisitContinueStmt(ContinueStmt *)
+        {
+            return false;
+        }
+
         bool VisitCXXThrowExpr(CXXThrowExpr *)
         {
             return false;
@@ -93,7 +98,10 @@ public:
     bool isBreakingPoint(Stmt *stmt)
     {
         return stmt && (isa<BreakStmt>(stmt) ||
-                isa<ReturnStmt>(stmt) || isa<CXXThrowExpr>(stmt) || isa<ObjCAtThrowStmt>(stmt));
+                        isa<ReturnStmt>(stmt) ||
+                        isa<CXXThrowExpr>(stmt) ||
+                        isa<ContinueStmt>(stmt) ||
+                        isa<ObjCAtThrowStmt>(stmt));
     }
 
     bool VisitSwitchStmt(SwitchStmt *switchStmt)

--- a/oclint-rules/test/convention/MissingBreakInSwitchStatementRuleTest.cpp
+++ b/oclint-rules/test/convention/MissingBreakInSwitchStatementRuleTest.cpp
@@ -127,6 +127,20 @@ default:      \n\
 } }");
 }
 
+TEST(MissingBreakInSwitchStatementRuleTest, SkipCasesWithContinue)
+{
+    testRuleOnCode(new MissingBreakInSwitchStatementRule(), "int aMethod(int a) {\n\
+for(int i=0;i<2;++i) {\n\
+\tswitch(a){  \n\
+\tcase 1:     \n\
+\t\tcontinue; \n\
+\tcase 2:     \n\
+\t\tcontinue; \n\
+\tdefault:    \n\
+\t\tcontinue; \n\
+} } }");
+}
+
 /*
  Tests for the false positive found by Stephan Esch
  Details at https://github.com/oclint/oclint/issues/16


### PR DESCRIPTION
Like break, return, etc., continue can escape the flow of a switch
statement when used inside a loop. It should not trigger the
MissingBreakInSwitchStatementRule.

Fixes #355