### PR TITLE
Add clang static analyzer bugs to pmd report

### DIFF
--- a/oclint-reporters/reporters/PMDReporter.cpp
+++ b/oclint-reporters/reporters/PMDReporter.cpp
@@ -22,6 +22,11 @@ public:
             writeViolation(out, violation);
             out << std::endl;
         }
+        for (const auto& violation : results->allCheckerBugs())
+        {
+            writeCheckerBug(out, violation);
+            out << std::endl;
+        }
         writeFooter(out);
     }
 
@@ -51,6 +56,23 @@ public:
             out << "rule=\"" << rule->name() << "\" ";
             out << "ruleset=\"" << rule->category() << "\" ";
         }
+        out << ">" << std::endl;
+        out << violation.message << std::endl;
+        out << "</violation>" << std::endl;
+        out << "</file>" << std::endl;
+    }
+
+    void writeCheckerBug(std::ostream &out, const Violation &violation)
+    {
+        out << "<file name=\"" << violation.path << "\">" << std::endl;
+        out << "<violation ";
+        out << "begincolumn=\"" << violation.startColumn << "\" ";
+        out << "endcolumn=\"" << violation.endColumn << "\" ";
+        out << "beginline=\"" << violation.startLine << "\" ";
+        out << "endline=\"" << violation.endLine << "\" ";
+        out << "priority=\"" << 2 << "\" ";
+        out << "rule=\"" << "clang static analyzer" << "\" ";
+        out << "ruleset=\"" << "cland static analyzer" << "\" ";
         out << ">" << std::endl;
         out << violation.message << std::endl;
         out << "</violation>" << std::endl;

--- a/oclint-reporters/test/PMDReporterTest.cpp
+++ b/oclint-reporters/test/PMDReporterTest.cpp
@@ -60,6 +60,21 @@ TEST_F(PMDReporterTest, WriteViolation)
     EXPECT_THAT(oss.str(), HasSubstr("test message"));
 }
 
+TEST_F(PMDReporterTest, WriteCheckerBug)
+{
+    Violation violation(nullptr, "test path", 1, 2, 3, 4, "test message");
+    std::ostringstream oss;
+    reporter.writeCheckerBug(oss, violation);
+    EXPECT_THAT(oss.str(), HasSubstr("<file name=\"test path\">"));
+    EXPECT_THAT(oss.str(), HasSubstr("<violation"));
+    EXPECT_THAT(oss.str(), HasSubstr("begincolumn=\"2\""));
+    EXPECT_THAT(oss.str(), HasSubstr("endcolumn=\"4\""));
+    EXPECT_THAT(oss.str(), HasSubstr("beginline=\"1\""));
+    EXPECT_THAT(oss.str(), HasSubstr("endline=\"3\""));
+    EXPECT_THAT(oss.str(), HasSubstr("priority=\"2\""));
+    EXPECT_THAT(oss.str(), HasSubstr("clang static analyzer"));
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleMock(&argc, argv);


### PR DESCRIPTION
The pmd report did not contain the static analyzer bugs when
`-enable-clang-static-analyzer` was set.

As the Violations generated by the dispatcher do not have a rule we just
set the priority to 2 and the rule and ruleset to "clang static analyzer".