### PR TITLE
Catching up with LLVM 3.9.0 final branch

### DIFF
--- a/oclint-driver/lib/ConfigFile.cpp
+++ b/oclint-driver/lib/ConfigFile.cpp
@@ -1,5 +1,7 @@
 #include "oclint/ConfigFile.h"
 
+#include <climits>
+
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/YAMLParser.h>
 

--- a/oclint-scripts/oclintscripts/path.py
+++ b/oclint-scripts/oclintscripts/path.py
@@ -73,10 +73,10 @@ class url:
     json_compilation_database = 'https://github.com/oclint/oclint-json-compilation-database.git'
     xcodebuild = 'https://github.com/oclint/oclint-xcodebuild.git'
 
-    clang_prebuilt_binary_for_xcode_8 = 'http://clang-snapshots.oclint.org/llvm-3.9.0-dev-snapshot-mac-10.12-xcode-8-oclint-16.07.11.tar.gz'
-    clang_prebuilt_binary_for_xcode_7 = 'http://clang-snapshots.oclint.org/llvm-3.8.1-final-mac-10.11-xcode-7-oclint-16.07.11.tar.gz'
-    clang_prebuilt_binary_for_ubuntu_lts_14 = 'http://clang-snapshots.oclint.org/llvm-3.8.1-final-ubuntu-14.04-oclint-16.07.11.tar.gz'
-    clang_prebuilt_binary_for_ubuntu_lts_16 = 'http://clang-snapshots.oclint.org/llvm-3.8.1-final-ubuntu-16.04-oclint-16.07.11.tar.gz'
+    clang_prebuilt_binary_for_xcode_8 = 'http://clang-snapshots.oclint.org/llvm-3.9.0-dev-snapshot-mac-10.12-xcode-8-oclint-16.09.01.tar.gz'
+    clang_prebuilt_binary_for_xcode_7 = 'http://clang-snapshots.oclint.org/llvm-3.9.0-final-mac-10.11-xcode-7-oclint-16.09.01.tar.gz'
+    clang_prebuilt_binary_for_ubuntu_lts_14 = 'http://clang-snapshots.oclint.org/llvm-3.9.0-final-ubuntu-14.04-oclint-16.09.01.tar.gz'
+    clang_prebuilt_binary_for_ubuntu_lts_16 = 'http://clang-snapshots.oclint.org/llvm-3.9.0-final-ubuntu-16.04-oclint-16.09.01.tar.gz'
 
 def cd(dir_path):
     os.chdir(dir_path)

--- a/oclint-scripts/oclintscripts/version.py
+++ b/oclint-scripts/oclintscripts/version.py
@@ -23,12 +23,10 @@ def llvm_branches():
     return [llvm_master_branch(), llvm_latest_release_branch()]
 
 def llvm_default_branch():
-    if environment.is_xcode8():
-        return llvm_master_branch()
     return llvm_latest_release_branch()
 
 def llvm_master_branch():
     return 'trunk'
 
 def llvm_latest_release_branch():
-    return 'tags/RELEASE_381/final'
+    return 'tags/RELEASE_390/final'


### PR DESCRIPTION
Even though the official LLVM/Clang prebuilt binaries have not been published, the `final` branch has been tagged already right before Apple's Sept 7 media event. So I am catching up with its changes, and hopefully it can unblock some Xcode 8 beta users.