### PR TITLE
Escape clang static analyzer message in pmd report

### DIFF
--- a/oclint-reporters/reporters/PMDReporter.cpp
+++ b/oclint-reporters/reporters/PMDReporter.cpp
@@ -8,6 +8,27 @@ using namespace oclint;
 
 class PMDReporter : public Reporter
 {
+private:
+    std::string xmlEscape(const std::string &data)
+    {
+        std::string output;
+        output.reserve(data.size());
+        for (const auto &c : data)
+        {
+            switch(c)
+            {
+                case '<':
+                    output += "&lt;";
+                    break;
+                case '>':
+                    output += "&gt;";
+                    break;
+                default:
+                    output += c;
+            }
+        }
+        return output;
+    }
 public:
     virtual const std::string name() const override
     {
@@ -74,7 +95,7 @@ public:
         out << "rule=\"" << "clang static analyzer" << "\" ";
         out << "ruleset=\"" << "cland static analyzer" << "\" ";
         out << ">" << std::endl;
-        out << violation.message << std::endl;
+        out << xmlEscape(violation.message) << std::endl;
         out << "</violation>" << std::endl;
         out << "</file>" << std::endl;
     }

--- a/oclint-reporters/test/PMDReporterTest.cpp
+++ b/oclint-reporters/test/PMDReporterTest.cpp
@@ -62,7 +62,7 @@ TEST_F(PMDReporterTest, WriteViolation)
 
 TEST_F(PMDReporterTest, WriteCheckerBug)
 {
-    Violation violation(nullptr, "test path", 1, 2, 3, 4, "test message");
+    Violation violation(nullptr, "test path", 1, 2, 3, 4, "test <message>");
     std::ostringstream oss;
     reporter.writeCheckerBug(oss, violation);
     EXPECT_THAT(oss.str(), HasSubstr("<file name=\"test path\">"));
@@ -73,6 +73,7 @@ TEST_F(PMDReporterTest, WriteCheckerBug)
     EXPECT_THAT(oss.str(), HasSubstr("endline=\"3\""));
     EXPECT_THAT(oss.str(), HasSubstr("priority=\"2\""));
     EXPECT_THAT(oss.str(), HasSubstr("clang static analyzer"));
+    EXPECT_THAT(oss.str(), HasSubstr("test &lt;message&gt;"));
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The message from the clang static analyzer may contain < and > symbols
which are common in templated code. These would be interpreted as
opening tags by the parser.

Fixes #384 

Maybe we should think about using a library for handling the xml/html/pmd reports.