### PR TITLE
Handle ObjC2 langOpts

### DIFF
--- a/oclint-driver/lib/Analytics.cpp
+++ b/oclint-driver/lib/Analytics.cpp
@@ -187,7 +187,7 @@ void oclint::Analytics::languageOption(clang::LangOptions langOpts)
       _languageCounter->operator[]("cpp") = 0;
       _languageCounter->operator[]("objc") = 0;
   }
-  if (langOpts.ObjC1)
+  if (langOpts.ObjC1 || langOpts.ObjC2)
   {
       int objc = _languageCounter->operator[]("objc");
       _languageCounter->operator[]("objc") = objc + 1;


### PR DESCRIPTION
- The `oclint::Analytics::langOption()` method doesn't handle ObjC2 correctly. 
- This PR adds support for checking either ObjC language version.