### PR TITLE
Just a few tweaks

### DIFF
--- a/oclint-driver/include/oclint/ConfigFile.h
+++ b/oclint-driver/include/oclint/ConfigFile.h
@@ -40,8 +40,12 @@ private:
     int _maxP1;
     int _maxP2;
     int _maxP3;
+    TriState _listEnabledRules = UNDEFINED;
     TriState _clangChecker = UNDEFINED;
     TriState _allowDuplicatedViolations = UNDEFINED;
+    TriState _enableGlobalAnalysis = UNDEFINED;
+    TriState _noAnalytics = UNDEFINED;
+    TriState _enableVerbose = UNDEFINED;
 
 public:
     explicit ConfigFile(const std::string &path);
@@ -56,8 +60,12 @@ public:
     llvm::Optional<int> maxP1() const;
     llvm::Optional<int> maxP2() const;
     llvm::Optional<int> maxP3() const;
+    llvm::Optional<bool> listEnabledRules() const;
     llvm::Optional<bool> clangChecker() const;
     llvm::Optional<bool> allowDuplicatedViolations() const;
+    llvm::Optional<bool> enableGlobalAnalysis() const;
+    llvm::Optional<bool> noAnalytics() const;
+    llvm::Optional<bool> enableVerbose() const;
 
     void mapping(llvm::yaml::IO& io);
 };

--- a/oclint-driver/lib/ConfigFile.cpp
+++ b/oclint-driver/lib/ConfigFile.cpp
@@ -182,6 +182,11 @@ static llvm::Optional<bool> createOptionalBool(const TriState value)
     }
 }
 
+llvm::Optional<bool> oclint::option::ConfigFile::listEnabledRules() const
+{
+    return createOptionalBool(_listEnabledRules);
+}
+
 llvm::Optional<bool> oclint::option::ConfigFile::clangChecker() const
 {
     return createOptionalBool(_clangChecker);
@@ -192,6 +197,21 @@ llvm::Optional<bool> oclint::option::ConfigFile::allowDuplicatedViolations() con
     return createOptionalBool(_allowDuplicatedViolations);
 }
 
+llvm::Optional<bool> oclint::option::ConfigFile::enableGlobalAnalysis() const
+{
+    return createOptionalBool(_enableGlobalAnalysis);
+}
+
+llvm::Optional<bool> oclint::option::ConfigFile::noAnalytics() const
+{
+    return createOptionalBool(_noAnalytics);
+}
+
+llvm::Optional<bool> oclint::option::ConfigFile::enableVerbose() const
+{
+    return createOptionalBool(_enableVerbose);
+}
+
 void oclint::option::ConfigFile::mapping(llvm::yaml::IO& inputOutput)
 {
     inputOutput.mapOptional("rules", _rules);
@@ -200,9 +220,13 @@ void oclint::option::ConfigFile::mapping(llvm::yaml::IO& inputOutput)
     inputOutput.mapOptional("rule-configurations", _ruleConfigurations);
     inputOutput.mapOptional("output", _output);
     inputOutput.mapOptional("report-type", _reportType);
+    inputOutput.mapOptional("list-enabled-rules", _listEnabledRules);
     inputOutput.mapOptional("max-priority-1", _maxP1);
     inputOutput.mapOptional("max-priority-2", _maxP2);
     inputOutput.mapOptional("max-priority-3", _maxP3);
     inputOutput.mapOptional("enable-clang-static-analyzer", _clangChecker);
     inputOutput.mapOptional("allow-duplicated-violations", _allowDuplicatedViolations);
+    inputOutput.mapOptional("enable-global-analysis", _enableGlobalAnalysis);
+    inputOutput.mapOptional("no-analytics", _noAnalytics);
+    inputOutput.mapOptional("enable-verbose", _enableVerbose);
 }

--- a/oclint-driver/lib/Options.cpp
+++ b/oclint-driver/lib/Options.cpp
@@ -171,11 +171,15 @@ static void processConfigFile(const std::string &path)
 
     updateArgIfSet(argOutput, config.output());
     updateArgIfSet(argReportType, config.reportType());
+    updateArgIfSet(argListEnabledRules, config.listEnabledRules());
     updateArgIfSet(argMaxP1, config.maxP1());
     updateArgIfSet(argMaxP2, config.maxP2());
     updateArgIfSet(argMaxP3, config.maxP3());
+    updateArgIfSet(argGlobalAnalysis, config.enableGlobalAnalysis());
     updateArgIfSet(argClangChecker, config.clangChecker());
     updateArgIfSet(argDuplications, config.allowDuplicatedViolations());
+    updateArgIfSet(argNoAnalytics, config.noAnalytics());
+    updateArgIfSet(argEnableVerbose, config.enableVerbose());
 }
 
 static void processConfigFiles()

--- a/oclint-driver/main.cpp
+++ b/oclint-driver/main.cpp
@@ -75,11 +75,10 @@ void disposeOutStream(ostream* out)
 
 void listRules()
 {
-    cerr << "Enabled rules:\n";
+    cout << "Enabled rules:" << endl;
     for (const std::string &ruleName : oclint::option::rulesetFilter().filteredRuleNames())
-    {
-        cerr << "- " << ruleName << "\n";
-    }
+        cout << " - " << ruleName;
+    cout << endl;
 }
 
 void printErrorLine(const char *errorMessage)

--- a/oclint-rules/rules/abstract/AbstractNullCheckRule.h
+++ b/oclint-rules/rules/abstract/AbstractNullCheckRule.h
@@ -85,7 +85,7 @@ protected:
         return isImplicitDeclRef(expr);
     }
 
-    std::string extractIdentifierFromImplicitCastExpr(clang::ImplicitCastExpr *implicitCastExpr)
+    string extractIdentifierFromImplicitCastExpr(clang::ImplicitCastExpr *implicitCastExpr)
     {
         if (!implicitCastExpr)
         {
@@ -101,7 +101,7 @@ protected:
         return declRefExpr ? declRefExpr->getFoundDecl()->getNameAsString() : "";
     }
 
-    std::string extractIdentifierFromBinaryOperator(clang::BinaryOperator *binaryOperator)
+    string extractIdentifierFromBinaryOperator(clang::BinaryOperator *binaryOperator)
     {
         clang::Expr *refExpr = binaryOperator->getLHS();
         if (isNullToPointer(refExpr))
@@ -112,13 +112,13 @@ protected:
             clang::dyn_cast_or_null<clang::ImplicitCastExpr>(refExpr));
     }
 
-    std::string extractIdentifierFromUnaryOperator(clang::UnaryOperator *unaryOperator)
+    string extractIdentifierFromUnaryOperator(clang::UnaryOperator *unaryOperator)
     {
         return extractIdentifierFromImplicitCastExpr(
             clang::dyn_cast_or_null<clang::ImplicitCastExpr>(unaryOperator->getSubExpr()));
     }
 
-    std::string extractIdentifierFromExpr(clang::Expr *expr)
+    string extractIdentifierFromExpr(clang::Expr *expr)
     {
         if (!expr)
         {
@@ -145,11 +145,11 @@ protected:
         public clang::RecursiveASTVisitor<VariableOfInterestInMemberExpr>
     {
     private:
-        std::string _variableName;
+        string _variableName;
         AbstractNullCheckRule *_rule;
 
     public:
-        bool hasVariableInExpr(std::string name, clang::Expr *expr, AbstractNullCheckRule *rule)
+        bool hasVariableInExpr(string name, clang::Expr *expr, AbstractNullCheckRule *rule)
         {
             _variableName = name;
             _rule = rule;
@@ -172,11 +172,11 @@ protected:
         public clang::RecursiveASTVisitor<VariableOfInterestInObjCMessageExpr>
     {
     private:
-        std::string _variableName;
+        string _variableName;
         AbstractNullCheckRule *_rule;
 
     public:
-        bool hasVariableInExpr(std::string name, clang::Expr *expr, AbstractNullCheckRule *rule)
+        bool hasVariableInExpr(string name, clang::Expr *expr, AbstractNullCheckRule *rule)
         {
             _variableName = name;
             _rule = rule;

--- a/oclint-rules/rules/abstract/AbstractNullCheckRule.h
+++ b/oclint-rules/rules/abstract/AbstractNullCheckRule.h
@@ -85,7 +85,7 @@ protected:
         return isImplicitDeclRef(expr);
     }
 
-    string extractIdentifierFromImplicitCastExpr(clang::ImplicitCastExpr *implicitCastExpr)
+    std::string extractIdentifierFromImplicitCastExpr(clang::ImplicitCastExpr *implicitCastExpr)
     {
         if (!implicitCastExpr)
         {
@@ -101,7 +101,7 @@ protected:
         return declRefExpr ? declRefExpr->getFoundDecl()->getNameAsString() : "";
     }
 
-    string extractIdentifierFromBinaryOperator(clang::BinaryOperator *binaryOperator)
+    std::string extractIdentifierFromBinaryOperator(clang::BinaryOperator *binaryOperator)
     {
         clang::Expr *refExpr = binaryOperator->getLHS();
         if (isNullToPointer(refExpr))
@@ -112,13 +112,13 @@ protected:
             clang::dyn_cast_or_null<clang::ImplicitCastExpr>(refExpr));
     }
 
-    string extractIdentifierFromUnaryOperator(clang::UnaryOperator *unaryOperator)
+    std::string extractIdentifierFromUnaryOperator(clang::UnaryOperator *unaryOperator)
     {
         return extractIdentifierFromImplicitCastExpr(
             clang::dyn_cast_or_null<clang::ImplicitCastExpr>(unaryOperator->getSubExpr()));
     }
 
-    string extractIdentifierFromExpr(clang::Expr *expr)
+    std::string extractIdentifierFromExpr(clang::Expr *expr)
     {
         if (!expr)
         {
@@ -145,11 +145,11 @@ protected:
         public clang::RecursiveASTVisitor<VariableOfInterestInMemberExpr>
     {
     private:
-        string _variableName;
+        std::string _variableName;
         AbstractNullCheckRule *_rule;
 
     public:
-        bool hasVariableInExpr(string name, clang::Expr *expr, AbstractNullCheckRule *rule)
+        bool hasVariableInExpr(std::string name, clang::Expr *expr, AbstractNullCheckRule *rule)
         {
             _variableName = name;
             _rule = rule;
@@ -168,15 +168,16 @@ protected:
         }
     };
 
+
     class VariableOfInterestInObjCMessageExpr :
         public clang::RecursiveASTVisitor<VariableOfInterestInObjCMessageExpr>
     {
     private:
-        string _variableName;
+        std::string _variableName;
         AbstractNullCheckRule *_rule;
 
     public:
-        bool hasVariableInExpr(string name, clang::Expr *expr, AbstractNullCheckRule *rule)
+        bool hasVariableInExpr(std::string name, clang::Expr *expr, AbstractNullCheckRule *rule)
         {
             _variableName = name;
             _rule = rule;

--- a/oclint-rules/rules/basic/BitwiseOperatorInConditionalRule.cpp
+++ b/oclint-rules/rules/basic/BitwiseOperatorInConditionalRule.cpp
@@ -25,19 +25,19 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Checks for bitwise operations in conditionals. Although being written on purpose "
             "in some rare cases, bitwise operations are considered to be too \"smart\". "
             "Smart code is not easy to understand.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/basic/BrokenNullCheckRule.cpp
+++ b/oclint-rules/rules/basic/BrokenNullCheckRule.cpp
@@ -79,17 +79,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "The broken null check itself will crash the program.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -141,23 +141,23 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "The broken nil check in Objective-C in some cases "
             "returns just the opposite result.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "BrokenNullCheckRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/basic/BrokenOddnessCheckRule.cpp
+++ b/oclint-rules/rules/basic/BrokenOddnessCheckRule.cpp
@@ -44,18 +44,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Checking oddness by ``x % 2 == 1`` won't work for negative numbers. "
             "Use ``x & 1 == 1``, or ``x % 2 != 0`` instead.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/basic/CollapsibleIfStatementsRule.cpp
+++ b/oclint-rules/rules/basic/CollapsibleIfStatementsRule.cpp
@@ -53,18 +53,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects instances where the conditions of two consecutive if statements "
             "can be combined into one in order to increase code cleanness and readability.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/basic/ConstantConditionalOperatorRule.cpp
+++ b/oclint-rules/rules/basic/ConstantConditionalOperatorRule.cpp
@@ -25,18 +25,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "``conditional operator`` whose conditionals are always true "
             "or always false are confusing.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/basic/ConstantIfExpressionRule.cpp
+++ b/oclint-rules/rules/basic/ConstantIfExpressionRule.cpp
@@ -24,18 +24,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.2";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "``if`` statements whose conditionals are always true "
             "or always false are confusing.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/basic/DeadCodeRule.cpp
+++ b/oclint-rules/rules/basic/DeadCodeRule.cpp
@@ -3,6 +3,7 @@
 #include "oclint/AbstractASTVisitorRule.h"
 #include "oclint/RuleSet.h"
 
+using namespace std;
 using namespace clang;
 using namespace oclint;
 
@@ -89,7 +90,7 @@ static bool isAnyReturnStmt(const Stmt& stmt)
 class DeadCodeRule : public AbstractASTVisitorRule<DeadCodeRule>
 {
 public:
-    virtual const std::string name() const override
+    virtual const string name() const override
     {
         return "dead code";
     }
@@ -99,24 +100,24 @@ public:
         return 2;
     }
 
-    virtual const std::string category() const override
+    virtual const string category() const override
     {
         return "basic";
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.4";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Code after ``return``, ``break``, ``continue``, and ``throw`` statements "
             "is unreachable and will never be executed.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/basic/DoubleNegativeRule.cpp
+++ b/oclint-rules/rules/basic/DoubleNegativeRule.cpp
@@ -35,17 +35,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "There is no point in using a double negative, it is always positive.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/basic/ForLoopShouldBeWhileLoopRule.cpp
+++ b/oclint-rules/rules/basic/ForLoopShouldBeWhileLoopRule.cpp
@@ -24,18 +24,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Under certain circumstances, some ``for`` loops can be simplified to while "
             "loops to make code more concise.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/basic/GotoStatementRule.cpp
+++ b/oclint-rules/rules/basic/GotoStatementRule.cpp
@@ -31,18 +31,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "`\"Go To Statement Considered Harmful\" "
             "<http://www.cs.utexas.edu/users/EWD/ewd02xx/EWD215.PDF>`_";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -56,7 +56,7 @@ public:
     )rst";
     }
 
-    virtual const std::string additionalDocument() const override
+    virtual const string additionalDocument() const override
     {
         return R"rst(
 **References:**

--- a/oclint-rules/rules/basic/JumbledIncrementerRule.cpp
+++ b/oclint-rules/rules/basic/JumbledIncrementerRule.cpp
@@ -57,18 +57,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Jumbled incrementers are usually typos. If it’s done on purpose, "
             "it’s very confusing for code readers.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/basic/MisplacedNullCheckRule.cpp
+++ b/oclint-rules/rules/basic/MisplacedNullCheckRule.cpp
@@ -79,24 +79,24 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "The null check is misplaced. "
             "In C and C++, sending a message to a null pointer could crash the program. "
             "When null is misplaced, either the check is useless or it's incorrect.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "MisplacedNullCheckRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -148,24 +148,24 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "The nil check is misplaced. "
             "In Objective-C, sending a message to a nil pointer simply does nothing. "
             "But code readers may be confused about the misplaced nil check.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "MisplacedNullCheckRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/basic/MultipleUnaryOperatorRule.cpp
+++ b/oclint-rules/rules/basic/MultipleUnaryOperatorRule.cpp
@@ -33,17 +33,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Multiple unary operator can always be confusing and should be simplified.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/basic/ReturnFromFinallyBlockRule.cpp
+++ b/oclint-rules/rules/basic/ReturnFromFinallyBlockRule.cpp
@@ -43,17 +43,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Returning from a ``finally`` block is not recommended.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/basic/ThrowExceptionFromFinallyBlockRule.cpp
+++ b/oclint-rules/rules/basic/ThrowExceptionFromFinallyBlockRule.cpp
@@ -84,18 +84,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Throwing exceptions within a ``finally`` block "
             "may mask other exceptions or code defects.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/cocoa/ObjCVerifyIsEqualHashRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyIsEqualHashRule.cpp
@@ -34,22 +34,22 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.8";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "When ``isEqual`` method is overridden, ``hash`` method must be overridden, too.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "ObjCVerifyIsEqualHashRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/cocoa/ObjCVerifyMustCallSuperRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyMustCallSuperRule.cpp
@@ -18,7 +18,7 @@ private:
     bool _foundSuperCall;
 public:
     explicit ContainsCallToSuperMethod(string selectorString)
-        : _selector(std::move(selectorString))
+        : _selector(move(selectorString))
     {
         _foundSuperCall = false;
     }
@@ -83,12 +83,12 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.8";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "When a method is declared with "
             "``__attribute__((annotate(\"oclint:enforce[base method]\")))`` annotation, "
@@ -96,12 +96,12 @@ public:
             "must call the method implementation in super class.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "ObjCVerifyMustCallSuperRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/cocoa/ObjCVerifyProhibitedCallRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyProhibitedCallRule.cpp
@@ -59,24 +59,24 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.10.1";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
          return "When a method is declared with "
             "``__attribute__((annotate(\"oclint:enforce[prohibited method]\")))`` "
             "annotation, all of its usages will be prohibited.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "ObjCVerifyProhibitedCallRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/cocoa/ObjCVerifyProtectedMethodRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifyProtectedMethodRule.cpp
@@ -95,12 +95,12 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.8";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Even though there is no ``protected`` in Objective-C language level, "
             "in a design's perspective, we sometimes hope to enforce a method only be used inside "
@@ -108,12 +108,12 @@ public:
             "and alerts developers when a method is called outside its access scope.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "ObjCVerifyProtectedMethodRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/cocoa/ObjCVerifySubclassMustImplementRule.cpp
+++ b/oclint-rules/rules/cocoa/ObjCVerifySubclassMustImplementRule.cpp
@@ -40,12 +40,12 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.8";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Due to the Objective-C language tries to postpone the decision makings "
             "to the runtime as much as possible, an abstract method is okay to be declared "
@@ -53,12 +53,12 @@ public:
             "the correct abstract method.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "ObjCVerifySubclassMustImplementRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/convention/AvoidBranchingStatementAsLastInLoopRule.cpp
+++ b/oclint-rules/rules/convention/AvoidBranchingStatementAsLastInLoopRule.cpp
@@ -50,18 +50,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Having branching statement as the last statement inside a loop is very confusing, "
             "and could largely be forgetting of something and turning into a bug.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/convention/BaseClassDestructorShouldBeVirtualOrProtectedRule.cpp
+++ b/oclint-rules/rules/convention/BaseClassDestructorShouldBeVirtualOrProtectedRule.cpp
@@ -1,7 +1,9 @@
 #include "oclint/AbstractASTVisitorRule.h"
 #include "oclint/RuleSet.h"
 
+using namespace std;
 using namespace clang;
+using namespace oclint;
 
 static bool hasVirtualOrProtectedDestructor(const CXXRecordDecl& cxxRecordDecl)
 {
@@ -15,7 +17,7 @@ static bool hasVirtualOrProtectedDestructor(const CXXRecordDecl& cxxRecordDecl)
         || cxxDestructorDecl->getAccess() == AS_protected;
 }
 
-static std::string getMessageViolation(const CXXRecordDecl& base, const CXXRecordDecl& child)
+static string getMessageViolation(const CXXRecordDecl& base, const CXXRecordDecl& child)
 {
     return "~" + base.getNameAsString() + "() should be protected or virtual"
         " according to class " + child.getNameAsString();
@@ -29,19 +31,19 @@ static std::string getMessageViolation(const CXXRecordDecl& base, const CXXRecor
  * If base class destructor is virtual, so the correct destructor is called.
  * If base class destructor is protected, it cannot be called from outside.
  *
- * To avoid false positive with 'type traits' class as std::true_type
+ * To avoid false positive with 'type traits' class as true_type
  * only check parents of polymorphic classes.
  */
 class BaseClassDestructorShouldBeVirtualOrProtectedRule :
-    public oclint::AbstractASTVisitorRule<BaseClassDestructorShouldBeVirtualOrProtectedRule>
+    public AbstractASTVisitorRule<BaseClassDestructorShouldBeVirtualOrProtectedRule>
 {
 public:
-    virtual const std::string name() const override
+    virtual const string name() const override
     {
         return "base class destructor should be virtual or protected";
     }
 
-    virtual const std::string identifier() const override
+    virtual const string identifier() const override
     {
         return "ProblematicBaseClassDestructor";
     }
@@ -51,33 +53,33 @@ public:
         return 2;
     }
 
-    virtual const std::string category() const override
+    virtual const string category() const override
     {
         return "convention";
     }
 
     unsigned int supportedLanguages() const override
     {
-        return oclint::LANG_CXX;
+        return LANG_CXX;
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.10.2";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Make base class destructor public and virtual, or protected and nonvirtual";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "BaseClassDestructorShouldBeVirtualOrProtectedRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -94,7 +96,7 @@ public:
         )rst";
     }
 
-    virtual const std::string additionalDocument() const override
+    virtual const string additionalDocument() const override
     {
         return R"rst(
 **References:**
@@ -149,4 +151,4 @@ private:
     }
 };
 
-static oclint::RuleSet rules(new BaseClassDestructorShouldBeVirtualOrProtectedRule());
+static RuleSet rules(new BaseClassDestructorShouldBeVirtualOrProtectedRule());

--- a/oclint-rules/rules/convention/CoveredSwitchStatementsDontNeedDefaultRule.cpp
+++ b/oclint-rules/rules/convention/CoveredSwitchStatementsDontNeedDefaultRule.cpp
@@ -30,12 +30,12 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.8";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "When a switch statement covers all possible cases, "
             "a default label is not needed and should be removed. "
@@ -43,12 +43,12 @@ public:
             "the SwitchStatementsShouldHaveDefault rule will report.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "CoveredSwitchStatementsDontNeedDefaultRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/convention/DefaultLabelNotLastInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/DefaultLabelNotLastInSwitchStatementRule.cpp
@@ -30,23 +30,23 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "It is very confusing when default label is not the last label "
             "in a switch statement.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "DefaultLabelNotLastInSwitchStatementRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/convention/DestructorOfVirtualClassRule.cpp
+++ b/oclint-rules/rules/convention/DestructorOfVirtualClassRule.cpp
@@ -1,7 +1,9 @@
 #include "oclint/AbstractASTVisitorRule.h"
 #include "oclint/RuleSet.h"
 
+using namespace std;
 using namespace clang;
+using namespace oclint;
 
 static bool hasVirtualDestructor(const CXXRecordDecl& cxxRecordDecl)
 {
@@ -10,17 +12,17 @@ static bool hasVirtualDestructor(const CXXRecordDecl& cxxRecordDecl)
     return cxxDestructorDecl != nullptr && cxxDestructorDecl->isVirtual();
 }
 
-static std::string getMessageViolation(const CXXRecordDecl& cxxRecordDecl)
+static string getMessageViolation(const CXXRecordDecl& cxxRecordDecl)
 {
-    const std::string& className = cxxRecordDecl.getNameAsString();
+    const string& className = cxxRecordDecl.getNameAsString();
     return "class " + className + " should have a virtual destructor ~" + className + "()";
 }
 
 class DestructorOfVirtualClassRule :
-    public oclint::AbstractASTVisitorRule<DestructorOfVirtualClassRule>
+    public AbstractASTVisitorRule<DestructorOfVirtualClassRule>
 {
 public:
-    virtual const std::string name() const override
+    virtual const string name() const override
     {
         return "destructor of virtual class";
     }
@@ -30,28 +32,28 @@ public:
         return 2;
     }
 
-    virtual const std::string category() const override
+    virtual const string category() const override
     {
         return "convention";
     }
 
     unsigned int supportedLanguages() const override
     {
-        return oclint::LANG_CXX;
+        return LANG_CXX;
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.8";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule enforces the destructor of a virtual class must be virtual.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -79,4 +81,4 @@ public:
     }
 };
 
-static oclint::RuleSet rules(new DestructorOfVirtualClassRule());
+static RuleSet rules(new DestructorOfVirtualClassRule());

--- a/oclint-rules/rules/convention/InvertedLogicRule.cpp
+++ b/oclint-rules/rules/convention/InvertedLogicRule.cpp
@@ -33,17 +33,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.4";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "An inverted logic is hard to understand.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/convention/MissingBreakInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/MissingBreakInSwitchStatementRule.cpp
@@ -59,18 +59,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "A switch statement without a break statement has a very large chance "
             "to contribute a bug.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/convention/NonCaseLabelInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/NonCaseLabelInSwitchStatementRule.cpp
@@ -44,17 +44,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "It is very confusing when label becomes part of the switch statement.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/convention/ObjCAssignIvarOutsideAccessorsRule.cpp
+++ b/oclint-rules/rules/convention/ObjCAssignIvarOutsideAccessorsRule.cpp
@@ -88,23 +88,23 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.8";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule prevents assigning an ivar outside of "
             "getters, setters, and ``init`` method.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "ObjCAssignIvarOutsideAccessorsRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/convention/ParameterReassignmentRule.cpp
+++ b/oclint-rules/rules/convention/ParameterReassignmentRule.cpp
@@ -72,17 +72,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Reassigning values to parameters is very problematic in most cases.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/convention/PreferEarlyExitRule.cpp
+++ b/oclint-rules/rules/convention/PreferEarlyExitRule.cpp
@@ -86,24 +86,24 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.8";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Early exits can reduce the indentation of a block of code, "
             "so that reader do not have to remember all the previous decisions, "
             "therefore, makes it easier to understand the code.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "PreferEarlyExitRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/convention/SwitchStatementsShouldHaveDefaultRule.cpp
+++ b/oclint-rules/rules/convention/SwitchStatementsShouldHaveDefaultRule.cpp
@@ -30,22 +30,22 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Switch statements should have a default statement.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "SwitchStatementsShouldHaveDefaultRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/convention/TooFewBranchesInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/TooFewBranchesInSwitchStatementRule.cpp
@@ -46,18 +46,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "To increase code readability, when a switch consists of only a few branches, "
             "it's much better to use an if statement instead.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -74,9 +74,9 @@ public:
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["MINIMUM_CASES_IN_SWITCH"] =
             "The reporting threshold for count of case statements in a switch statement, "
             "default value is 3.";

--- a/oclint-rules/rules/design/AvoidDefaultArgumentsOnVirtualMethodsRule.cpp
+++ b/oclint-rules/rules/design/AvoidDefaultArgumentsOnVirtualMethodsRule.cpp
@@ -34,18 +34,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.10.1";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Giving virtual functions default argument initializers tends to "
             "defeat polymorphism and introduce unnecessary complexity into a class hierarchy.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/design/AvoidPrivateStaticMembersRule.cpp
+++ b/oclint-rules/rules/design/AvoidPrivateStaticMembersRule.cpp
@@ -39,17 +39,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.10.1";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Having static members is easier to harm encapsulation.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/empty/EmptyCatchStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyCatchStatementRule.cpp
@@ -26,18 +26,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects instances where an exception is caught, "
             "but nothing is done about it.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/empty/EmptyDoWhileStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyDoWhileStatementRule.cpp
@@ -26,17 +26,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects instances where do-while statement does nothing.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/empty/EmptyElseBlockRule.cpp
+++ b/oclint-rules/rules/empty/EmptyElseBlockRule.cpp
@@ -26,22 +26,22 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects instances where a else statement does nothing.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "EmptyElseBlockRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/empty/EmptyFinallyStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyFinallyStatementRule.cpp
@@ -26,17 +26,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects instances where a finally statement does nothing.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/empty/EmptyForStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyForStatementRule.cpp
@@ -26,17 +26,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects instances where a for statement does nothing.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/empty/EmptyIfStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyIfStatementRule.cpp
@@ -26,18 +26,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.2";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects instances where a condition is checked, "
             "but nothing is done about it.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/empty/EmptySwitchStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptySwitchStatementRule.cpp
@@ -26,17 +26,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects instances where a switch statement does nothing.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/empty/EmptyTryStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyTryStatementRule.cpp
@@ -26,17 +26,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects instances where a try statement is empty.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/empty/EmptyWhileStatementRule.cpp
+++ b/oclint-rules/rules/empty/EmptyWhileStatementRule.cpp
@@ -26,17 +26,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects instances where a while statement does nothing.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/migration/ObjCBoxedExpressionsRule.cpp
+++ b/oclint-rules/rules/migration/ObjCBoxedExpressionsRule.cpp
@@ -99,23 +99,23 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule locates the places that can be migrated to the "
             "new Objective-C literals with boxed expressions.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "ObjCBoxedExpressionsRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/migration/ObjCContainerLiteralsRule.cpp
+++ b/oclint-rules/rules/migration/ObjCContainerLiteralsRule.cpp
@@ -30,23 +30,23 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule locates the places that can be migrated to the "
             "new Objective-C literals with container literals.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "ObjCContainerLiteralsRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/migration/ObjCNSNumberLiteralsRule.cpp
+++ b/oclint-rules/rules/migration/ObjCNSNumberLiteralsRule.cpp
@@ -93,23 +93,23 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule locates the places that can be migrated to the "
             "new Objective-C literals with number literals.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "ObjCNSNumberLiteralsRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/migration/ObjCObjectSubscriptingRule.cpp
+++ b/oclint-rules/rules/migration/ObjCObjectSubscriptingRule.cpp
@@ -71,23 +71,23 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule locates the places that can be migrated to the "
             "new Objective-C literals with object subscripting.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "ObjCObjectSubscriptingRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/naming/LongVariableNameRule.cpp
+++ b/oclint-rules/rules/naming/LongVariableNameRule.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include "oclint/AbstractASTVisitorRule.h"
 #include "oclint/RuleConfiguration.h"
 #include "oclint/RuleSet.h"
@@ -64,6 +65,7 @@ public:
         int threshold = RuleConfiguration::intForKey("LONG_VARIABLE_NAME", 20);
         if (nameLength > threshold)
         {
+            if (nameLength > threshold + 10) varName = varName.substr(0, threshold + 5) + "[...]";
             string description = "Length of variable name `" + varName + "` is " + toString<int>(nameLength) + ", which is longer than the threshold of " + toString<int>(threshold);
             addViolation(varDecl, this, description);
         }

--- a/oclint-rules/rules/naming/LongVariableNameRule.cpp
+++ b/oclint-rules/rules/naming/LongVariableNameRule.cpp
@@ -27,17 +27,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Variables with long names harm readability.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -49,9 +49,9 @@ public:
     )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["LONG_VARIABLE_NAME"] =
             "The long variable name reporting threshold, default value is 20.";
         return thresholdMapping;
@@ -60,7 +60,7 @@ public:
 
     bool VisitVarDecl(VarDecl *varDecl)
     {
-        std::string varName = varDecl->getNameAsString();
+        string varName = varDecl->getNameAsString();
         int nameLength = varName.size();
         int threshold = RuleConfiguration::intForKey("LONG_VARIABLE_NAME", 20);
         if (nameLength > threshold)

--- a/oclint-rules/rules/naming/ShortVariableNameRule.cpp
+++ b/oclint-rules/rules/naming/ShortVariableNameRule.cpp
@@ -12,7 +12,7 @@ using namespace oclint;
 class ShortVariableNameRule : public AbstractASTVisitorRule<ShortVariableNameRule>
 {
 private:
-    std::stack<VarDecl *> _suppressVarDecls;
+    stack<VarDecl *> _suppressVarDecls;
 
     void clearVarDeclsStack()
     {
@@ -68,19 +68,19 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "A variable with a short name is hard to understand what it stands for. "
             "Variable with name, but the name has number of characters less than the "
             "threshold will be emitted.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -92,9 +92,9 @@ public:
     )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["SHORT_VARIABLE_NAME"] =
             "The short variable name reporting threshold, default value is 3.";
         return thresholdMapping;
@@ -103,7 +103,7 @@ public:
 
     bool VisitVarDecl(VarDecl *varDecl)
     {
-        std::string varName = varDecl->getNameAsString();
+        string varName = varDecl->getNameAsString();
         int nameLength = varName.size();
         int threshold = RuleConfiguration::intForKey("SHORT_VARIABLE_NAME", 3);
         if (nameLength <= 0 || nameLength >= threshold)

--- a/oclint-rules/rules/redundant/RedundantConditionalOperatorRule.cpp
+++ b/oclint-rules/rules/redundant/RedundantConditionalOperatorRule.cpp
@@ -161,12 +161,12 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return R"rst(
 This rule detects three types of redundant conditional operators:
@@ -179,7 +179,7 @@ They are usually introduced by mistake, and should be simplified.
         )rst";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/redundant/RedundantIfStatementRule.cpp
+++ b/oclint-rules/rules/redundant/RedundantIfStatementRule.cpp
@@ -91,17 +91,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.4";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects unnecessary if statements.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/redundant/RedundantLocalVariableRule.cpp
+++ b/oclint-rules/rules/redundant/RedundantLocalVariableRule.cpp
@@ -58,18 +58,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.4";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects cases where a variable declaration is immediately "
             "followed by a return of that variable.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/redundant/RedundantNilCheckRule.cpp
+++ b/oclint-rules/rules/redundant/RedundantNilCheckRule.cpp
@@ -61,19 +61,19 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "C/C++-style null check in Objective-C like ``foo != nil && [foo bar]`` "
             "is redundant, since sending a message to a nil object in this case "
             "simply returns a false-y value.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: objective-c

--- a/oclint-rules/rules/redundant/UnnecessaryElseStatementRule.cpp
+++ b/oclint-rules/rules/redundant/UnnecessaryElseStatementRule.cpp
@@ -88,12 +88,12 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "When an if statement block ends with a return statement, "
             "or all branches in the if statement block end with return statements, "
@@ -101,7 +101,7 @@ public:
             "can be run without being in the block.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/redundant/UnnecessaryNullCheckForCXXDeallocRule.cpp
+++ b/oclint-rules/rules/redundant/UnnecessaryNullCheckForCXXDeallocRule.cpp
@@ -2,7 +2,9 @@
 #include "oclint/RuleSet.h"
 #include "oclint/util/ASTUtil.h"
 
+using namespace std;
 using namespace clang;
+using namespace oclint;
 
 static bool IsCondNoNullPointerForBinOp(const BinaryOperator& binOp, const Expr** exprPointer)
 {
@@ -94,10 +96,10 @@ static bool IsADeleteBlock(ASTContext& context, const Stmt& stmt, const Expr* ex
 }
 
 class UnnecessaryNullCheckForCXXDeallocRule :
-    public oclint::AbstractASTVisitorRule<UnnecessaryNullCheckForCXXDeallocRule>
+    public AbstractASTVisitorRule<UnnecessaryNullCheckForCXXDeallocRule>
 {
 public:
-    virtual const std::string name() const override
+    virtual const string name() const override
     {
         return "unnecessary null check for dealloc";
     }
@@ -107,34 +109,34 @@ public:
         return 3;
     }
 
-    virtual const std::string category() const override
+    virtual const string category() const override
     {
         return "redundant";
     }
 
     virtual unsigned int supportedLanguages() const override
     {
-        return oclint::LANG_CXX;
+        return LANG_CXX;
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.8";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "``char* p = 0; delete p;`` is valid. "
             "This rule locates unnecessary ``if (p)`` checks.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "UnnecessaryNullCheckForCXXDeallocRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -168,4 +170,4 @@ public:
     }
 };
 
-static oclint::RuleSet rules(new UnnecessaryNullCheckForCXXDeallocRule);
+static RuleSet rules(new UnnecessaryNullCheckForCXXDeallocRule);

--- a/oclint-rules/rules/redundant/UselessParenthesesRule.cpp
+++ b/oclint-rules/rules/redundant/UselessParenthesesRule.cpp
@@ -33,17 +33,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects useless parentheses.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/size/CyclomaticComplexityRule.cpp
+++ b/oclint-rules/rules/size/CyclomaticComplexityRule.cpp
@@ -48,12 +48,12 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.4";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return R"rst(
 Cyclomatic complexity is determined by the number of linearly independent paths
@@ -67,12 +67,12 @@ the cyclomatic complexity of 10 is a reasonable upper limit.
         )rst";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "CyclomaticComplexityRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -107,15 +107,15 @@ the cyclomatic complexity of 10 is a reasonable upper limit.
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["CYCLOMATIC_COMPLEXITY"] =
             "The cyclomatic complexity reporting threshold, default value is 10.";
         return thresholdMapping;
     }
 
-    virtual const std::string additionalDocument() const override
+    virtual const string additionalDocument() const override
     {
         return R"rst(
 **References:**

--- a/oclint-rules/rules/size/LongClassRule.cpp
+++ b/oclint-rules/rules/size/LongClassRule.cpp
@@ -41,18 +41,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Long class generally indicates that this class tries to do many things. "
             "Each class should do one thing and that one thing well.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -67,9 +67,9 @@ public:
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["LONG_CLASS"] =
             "The class size reporting threshold, default value is 1000.";
         return thresholdMapping;

--- a/oclint-rules/rules/size/LongLineRule.cpp
+++ b/oclint-rules/rules/size/LongLineRule.cpp
@@ -25,18 +25,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "When the number of characters for one line of code is very high, "
             "it largely harms the readability. Break long lines of code into multiple lines.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -48,9 +48,9 @@ public:
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["LONG_LINE"] = "The long line reporting threshold, default value is 100.";
         return thresholdMapping;
     }

--- a/oclint-rules/rules/size/LongMethodRule.cpp
+++ b/oclint-rules/rules/size/LongMethodRule.cpp
@@ -45,18 +45,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.4";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Long method generally indicates that this method tries to do many things. "
             "Each method should do one thing and that one thing well.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -70,9 +70,9 @@ public:
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["LONG_METHOD"] =
             "The long method reporting threshold, default value is 50.";
         return thresholdMapping;

--- a/oclint-rules/rules/size/NPathComplexityRule.cpp
+++ b/oclint-rules/rules/size/NPathComplexityRule.cpp
@@ -59,12 +59,12 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.4";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return R"rst(
 NPath complexity is determined by the number of execution paths through that method.
@@ -77,12 +77,12 @@ an NPath threshold value of 200 has been established for a method.
         )rst";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "NPathComplexityRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -94,15 +94,15 @@ an NPath threshold value of 200 has been established for a method.
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["NPATH_COMPLEXITY"] =
             "The NPath complexity reporting threshold, default value is 200.";
         return thresholdMapping;
     }
 
-    virtual const std::string additionalDocument() const override
+    virtual const string additionalDocument() const override
     {
         return R"rst(
 **References:**

--- a/oclint-rules/rules/size/NcssMethodCountRule.cpp
+++ b/oclint-rules/rules/size/NcssMethodCountRule.cpp
@@ -40,12 +40,12 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule counts number of lines for a method by "
             "counting Non Commenting Source Statements (NCSS). "
@@ -55,12 +55,12 @@ public:
             "Meanwhile, a statement that is broken into multiple lines contribute only one count.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "NcssMethodCountRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -77,9 +77,9 @@ public:
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["NCSS_METHOD"] =
             "The high NCSS method reporting threshold, default value is 30.";
         return thresholdMapping;

--- a/oclint-rules/rules/size/NestedBlockDepthRule.cpp
+++ b/oclint-rules/rules/size/NestedBlockDepthRule.cpp
@@ -27,22 +27,22 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.6";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule indicates blocks nested more deeply than the upper limit.";
     }
 
-    virtual const std::string fileName() const override
+    virtual const string fileName() const override
     {
         return "NestedBlockDepthRule.cpp";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -57,9 +57,9 @@ public:
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["NESTED_BLOCK_DEPTH"] =
             "The depth of a block or compound statement reporting threshold, default value is 5.";
         return thresholdMapping;

--- a/oclint-rules/rules/size/TooManyFieldsRule.cpp
+++ b/oclint-rules/rules/size/TooManyFieldsRule.cpp
@@ -29,18 +29,18 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "A class with too many fields indicates it does too many things "
             "and lacks proper abstraction. It can be redesigned to have fewer fields.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -60,9 +60,9 @@ public:
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["TOO_MANY_FIELDS"] =
             "The reporting threshold for too many fields, default value is 20.";
         return thresholdMapping;

--- a/oclint-rules/rules/size/TooManyMethodsRule.cpp
+++ b/oclint-rules/rules/size/TooManyMethodsRule.cpp
@@ -29,19 +29,19 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "A class with too many methods indicates it does too many things "
             "and is hard to read and understand. "
             "It usually contains complicated code, and should be refactored.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -68,9 +68,9 @@ public:
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["TOO_MANY_METHODS"] =
             "The reporting threshold for too many methods, default value is 30.";
         return thresholdMapping;

--- a/oclint-rules/rules/size/TooManyParametersRule.cpp
+++ b/oclint-rules/rules/size/TooManyParametersRule.cpp
@@ -41,12 +41,12 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.7";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "Methods with too many parameters are hard to understand and maintain, "
             "and are thirsty for refactorings, like `Replace Parameter With method "
@@ -57,7 +57,7 @@ public:
             "<http://www.refactoring.com/catalog/preserveWholeObject.html>`_.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp
@@ -69,15 +69,15 @@ public:
         )rst";
     }
 
-    virtual const std::map<std::string, std::string> thresholds() const override
+    virtual const map<string, string> thresholds() const override
     {
-        std::map<std::string, std::string> thresholdMapping;
+        map<string, string> thresholdMapping;
         thresholdMapping["TOO_MANY_PARAMETERS"] =
             "The reporting threshold for too many parameters, default value is 10.";
         return thresholdMapping;
     }
 
-    virtual const std::string additionalDocument() const override
+    virtual const string additionalDocument() const override
     {
         return R"rst(
 **References:**

--- a/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
+++ b/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
@@ -39,7 +39,7 @@ public:
     UnusedLocalVariableRule()
     {
         string defKeys = RuleConfiguration::stringForKey("RAII_DEFAULT_CLASSES",
-            "lock_guard, unique_lock");
+            "std::lock_guard, std::unique_lock");
         string cusKeys = RuleConfiguration::stringForKey("RAII_CUSTOM_CLASSES", "");
 
         resetSkippedTypes({ defKeys, cusKeys });

--- a/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
+++ b/oclint-rules/rules/unused/UnusedLocalVariableRule.cpp
@@ -39,7 +39,7 @@ public:
     UnusedLocalVariableRule()
     {
         string defKeys = RuleConfiguration::stringForKey("RAII_DEFAULT_CLASSES",
-            "std::lock_guard, std::unique_lock");
+            "lock_guard, unique_lock");
         string cusKeys = RuleConfiguration::stringForKey("RAII_CUSTOM_CLASSES", "");
 
         resetSkippedTypes({ defKeys, cusKeys });
@@ -52,9 +52,9 @@ protected:
      * In the regular operation mode, this part should be only triggered within the ctor
      *
      * @param newIgnoreTypes The new types to insert accordingly
-     * @throw std::invalid_argument, in case that the given input contains a failure
+     * @throw invalid_argument, in case that the given input contains a failure
      */
-    void resetSkippedTypes(const std::list<string> & newIgnoreTypes)
+    void resetSkippedTypes(const list<string> & newIgnoreTypes)
     {
         skippedTypes.clear();
         for (auto const & curKeys : newIgnoreTypes)
@@ -150,17 +150,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.4";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects local variables that are declared, but not used.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/rules/unused/UnusedMethodParameterRule.cpp
+++ b/oclint-rules/rules/unused/UnusedMethodParameterRule.cpp
@@ -144,17 +144,17 @@ public:
     }
 
 #ifdef DOCGEN
-    virtual const std::string since() const override
+    virtual const string since() const override
     {
         return "0.4";
     }
 
-    virtual const std::string description() const override
+    virtual const string description() const override
     {
         return "This rule detects parameters that are not used in the method.";
     }
 
-    virtual const std::string example() const override
+    virtual const string example() const override
     {
         return R"rst(
 .. code-block:: cpp

--- a/oclint-rules/test/naming/LongVariableNameRuleTest.cpp
+++ b/oclint-rules/test/naming/LongVariableNameRuleTest.cpp
@@ -54,3 +54,8 @@ TEST_F(LongVariableNameRuleTest, FiveCharsName)
     testRuleOnCode(new LongVariableNameRule(), "void aMethod() { int iiiii; }",
         0, 1, 18, 1, 22, "Length of variable name `iiiii` is 5, which is longer than the threshold of 3");
 }
+TEST_F(LongVariableNameRuleTest, FifteenCharsName)
+{
+    testRuleOnCode(new LongVariableNameRule(), "void aMethod() { int iiiiiiiiiiiiiii; }",
+        0, 1, 18, 1, 22, "Length of variable name `iiiiiiii[...]` is 15, which is longer than the threshold of 3");
+}

--- a/oclint-scripts/build
+++ b/oclint-scripts/build
@@ -24,6 +24,10 @@ arg_parser.add_argument('-llvm-root', '--llvm-root', default=path.build.clang_in
 arg_parser.add_argument('-use-system-compiler', '--use-system-compiler', action="store_true", default=environment.is_linux())
 args = arg_parser.parse_args()
 
+multiple_thread = environment.cpu_count()
+if environment.is_mingw32(): multiple_thread = "1"
+if not args.j is 0: multiple_thread = str(args.j)
+
 def clean_module(module_name):
     build_path = path.oclint_module_build_dir(module_name)
     path.rm_f(build_path)
@@ -63,7 +67,7 @@ def build_module(module_name, llvm_root, is_release, no_analytics, is_docgen, mu
     path.mkdir_p(build_path)
     path.cd(build_path)
     process.call(command)
-    process.call('make -j ' + multiple_thread)
+    process.call('make -j' + multiple_thread)
     path.cd(current_dir)
 
 build_modules = []
@@ -75,12 +79,6 @@ else:
 if args.clean:
     for module in build_modules:
         clean_module(module)
-
-multiple_thread = environment.cpu_count()
-if environment.is_mingw32():
-    multiple_thread = 1
-if not args.j is 0:
-    multiple_thread = args.j
 
 for module in build_modules:
     build_module(module, args.llvm_root, args.release, args.no_analytics, args.docgen, str(multiple_thread))

--- a/oclint-scripts/ci
+++ b/oclint-scripts/ci
@@ -17,7 +17,12 @@ arg_parser.add_argument('-setup', '--setup', action="store_true")
 arg_parser.add_argument('-llvm-branch', '--llvm-branch', nargs='?', choices=version.llvm_branches(), default=version.llvm_default_branch())
 arg_parser.add_argument('-release', '--release', action="store_true")
 arg_parser.add_argument('-archive', '--archive', action="store_true")
+arg_parser.add_argument('-j', type=int, default=0)
 args = arg_parser.parse_args()
+
+multiple_thread = environment.cpu_count()
+if environment.is_mingw32(): multiple_thread = "1"
+if not args.j is 0: multiple_thread = str(args.j)
 
 def upload_snapshot():
     process.call('python upload')
@@ -38,21 +43,21 @@ if args.setup:
     if environment.is_darwin():
         process.call('git clone ' + path.url.xcodebuild)
     path.cd(current_dir)
-    process.call('python clang co -branch ' + args.llvm_branch)
-    process.call('python countly co')
+    process.call('python clang co -branch ' + args.llvm_branch + '-j' + multiple_thread)
+    process.call('python countly co -j' + multiple_thread)
     if args.release:
-        process.call('python clang build -release -clean')
+        process.call('python clang build -release -clean -j' + multiple_thread)
     else:
-        process.call('python googleTest co')
-        process.call('python clang build -clean')
-        process.call('python googleTest build -clean')
-    process.call('python countly build')
+        process.call('python googleTest co -j' + multiple_thread)
+        process.call('python clang build -clean -j' + multiple_thread)
+        process.call('python googleTest build -clean -j' + multiple_thread)
+    process.call('python countly build -j' + multiple_thread)
 
 if args.release:
-    process.call('python build -clean -release')
+    process.call('python build -clean -release -j' + multiple_thread)
 else:
-    process.call('python test -clean')
-    process.call('python build -clean')
+    process.call('python test -clean -j' + multiple_thread)
+    process.call('python build -clean -j' + multiple_thread)
 process.call('python bundle')
 if environment.is_unix() and not args.release:
     process.call('python dogFooding -enable-clang-static-analyzer')

--- a/oclint-scripts/clang
+++ b/oclint-scripts/clang
@@ -21,6 +21,10 @@ arg_parser.add_argument('-release', '--release', action="store_true")
 arg_parser.add_argument('-j', type=int, default=0)
 args = arg_parser.parse_args()
 
+multiple_thread = environment.cpu_count()
+if environment.is_mingw32(): multiple_thread = "1"
+if not args.j is 0: multiple_thread = str(args.j)
+
 def clean_module():
     build_path = path.build.clang_build_dir
     path.rm_f(build_path)
@@ -51,8 +55,8 @@ def build_module(is_release, multiple_thread):
     path.mkdir_p(build_path)
     path.cd(build_path)
     process.call(command)
-    process.call('make -j ' + multiple_thread)
-    process.call('make install')
+    process.call('make -j' + multiple_thread)
+    process.call('make install -j' + multiple_thread)
     path.cd(current_dir)
 
 def copy_cpp_headers():
@@ -122,12 +126,6 @@ if args.task_name == 'update' or args.task_name == 'up':
 
 if args.task_name == 'prebuilt':
     setup_prebuilt_binary()
-
-multiple_thread = environment.cpu_count()
-if environment.is_mingw32():
-    multiple_thread = 1
-if not args.j is 0:
-    multiple_thread = args.j
 
 if args.task_name == 'build':
     if args.clean:

--- a/oclint-scripts/countly
+++ b/oclint-scripts/countly
@@ -19,6 +19,10 @@ arg_parser.add_argument('-j', type=int, default=0)
 arg_parser.add_argument('-use-system-compiler', '--use-system-compiler', action="store_true", default=environment.is_linux())
 args = arg_parser.parse_args()
 
+multiple_thread = environment.cpu_count()
+if environment.is_mingw32(): multiple_thread = "1"
+if not args.j is 0: multiple_thread = str(args.j)
+
 def clean_module():
     build_path = path.build.countly_build_dir
     path.rm_f(build_path)
@@ -37,7 +41,7 @@ def build_module(multiple_thread):
     path.mkdir_p(build_path)
     path.cd(build_path)
     process.call(command)
-    process.call('make -j ' + multiple_thread)
+    process.call('make -j' + multiple_thread)
     path.cd(current_dir)
 
 def checkout_countly():
@@ -50,10 +54,6 @@ def checkout_countly():
 
 if args.task_name == 'checkout' or args.task_name == 'co':
     checkout_countly()
-
-multiple_thread = environment.cpu_count()
-if not args.j is 0:
-    multiple_thread = args.j
 
 if args.task_name == 'build':
     if args.clean:

--- a/oclint-scripts/googleTest
+++ b/oclint-scripts/googleTest
@@ -18,6 +18,10 @@ arg_parser.add_argument('-j', type=int, default=0)
 arg_parser.add_argument('-use-system-compiler', '--use-system-compiler', action="store_true", default=environment.is_linux())
 args = arg_parser.parse_args()
 
+multiple_thread = environment.cpu_count()
+if environment.is_mingw32(): multiple_thread = "1"
+if not args.j is 0: multiple_thread = str(args.j)
+
 def clean_module():
     build_path = path.build.googletest_build_dir
     path.rm_f(build_path)
@@ -42,7 +46,7 @@ def build_module(multiple_thread):
     path.mkdir_p(build_path)
     path.cd(build_path)
     process.call(command)
-    process.call('make -j ' + multiple_thread)
+    process.call('make -j' + multiple_thread)
     path.cd(current_dir)
 
 def checkout_googletest():
@@ -66,12 +70,6 @@ if args.task_name == 'checkout' or args.task_name == 'co':
 
 if args.task_name == 'update' or args.task_name == 'up':
     update_googletest()
-
-multiple_thread = environment.cpu_count()
-if environment.is_mingw32():
-    multiple_thread = 1
-if not args.j is 0:
-    multiple_thread = args.j
 
 if args.task_name == 'build':
     if args.clean:

--- a/oclint-scripts/make
+++ b/oclint-scripts/make
@@ -1,4 +1,4 @@
 #! /bin/sh -e
 
-./ci -reset
-./ci -setup -release
+./ci -reset "$@"
+./ci -setup -release "$@"

--- a/oclint-scripts/test
+++ b/oclint-scripts/test
@@ -22,6 +22,10 @@ arg_parser.add_argument('-use-system-compiler', '--use-system-compiler', action=
 arg_parser.add_argument('-as-dep', '--as-dep', action="store_true")
 args = arg_parser.parse_args()
 
+multiple_thread = environment.cpu_count()
+if environment.is_mingw32(): multiple_thread = "1"
+if not args.j is 0: multiple_thread = str(args.j)
+
 def clean_module(module_name):
     test_path = path.oclint_module_test_dir(module_name)
     path.rm_f(test_path);
@@ -62,7 +66,7 @@ def test_module(module_name, multiple_thread):
     path.mkdir_p(build_path)
     path.cd(build_path)
     process.call(command)
-    process.call('make -j ' + multiple_thread)
+    process.call('make -j' + multiple_thread)
     if not args.as_dep:
         run_ctest_command = 'ctest --output-on-failure > ' + test_result_path(module_name)
         ctest_exit_code = subprocess.call(run_ctest_command, shell=True)
@@ -85,12 +89,6 @@ if args.show:
 if args.clean:
     for module in build_modules:
         clean_module(module)
-
-multiple_thread = environment.cpu_count()
-if environment.is_mingw32():
-    multiple_thread = 1
-if not args.j is 0:
-    multiple_thread = args.j
 
 for module in build_modules:
     test_module(module, str(multiple_thread))


### PR DESCRIPTION
- Addon to #408.  Long Variable Names longer than the threshold + 10 will be cut off to minimize output data size, and save screen space.
- Cleaned up rules formatting to remove redundant uses of "std::" and "oclint::"
- Add all command-line options to ~/.oclint's control
- Add multithreading to all `make` commands