### PR TITLE
Correct false/postive in MissingBreakStatement

### DIFF
--- a/oclint-rules/rules/convention/MissingBreakInSwitchStatementRule.cpp
+++ b/oclint-rules/rules/convention/MissingBreakInSwitchStatementRule.cpp
@@ -15,6 +15,10 @@ class MissingBreakInSwitchStatementRule :
         {
             return !TraverseStmt(switchCaseStmt);
         }
+        bool findSubBreak(Stmt *cleanupStmt)
+        {
+            return !TraverseStmt(cleanupStmt);
+        }
 
         bool VisitBreakStmt(BreakStmt *)
         {
@@ -97,11 +101,17 @@ public:
 
     bool isBreakingPoint(Stmt *stmt)
     {
+        bool isSubClean = isa<ExprWithCleanups>(stmt) || isa<CompoundStmt>(stmt);
+        if (isSubClean) {
+            FindingBreak findingBreak;
+            isSubClean = findingBreak.findSubBreak(stmt);
+        }
         return stmt && (isa<BreakStmt>(stmt) ||
                         isa<ReturnStmt>(stmt) ||
                         isa<CXXThrowExpr>(stmt) ||
                         isa<ContinueStmt>(stmt) ||
-                        isa<ObjCAtThrowStmt>(stmt));
+                        isa<ObjCAtThrowStmt>(stmt) ||
+                        isSubClean);
     }
 
     bool VisitSwitchStmt(SwitchStmt *switchStmt)

--- a/oclint-rules/test/convention/MissingBreakInSwitchStatementRuleTest.cpp
+++ b/oclint-rules/test/convention/MissingBreakInSwitchStatementRuleTest.cpp
@@ -156,3 +156,31 @@ case 1:     \n\
 \tbreak;    \n\
 } }");
 }
+
+TEST(MissingBreakInSwitchStatementRuleTest, CaseWithCXXCtorThrow)
+{
+	testRuleOnCXXCode(new MissingBreakInSwitchStatementRule(),
+"class ExcClass {public: ExcClass() {} }; \n\
+int aMethod(int a) {                      \n\
+int res = 123;                            \n\
+switch(a) {                               \n\
+case 1:                                   \n\
+\tres = 1;                                \n\
+\tthrow 123;                              \n\
+case 2:                                   \n\
+\tres = 2;                                \n\
+\tthrow \"abc\";                          \n\
+case 3:                                   \n\
+\tres = 3;                                \n\
+\tthrow ExcClass();                       \n\
+case 4:                                   \n\
+\tres += 1;                               \n\
+\t{                                       \n\
+\t\tthrow ExcClass();                     \n\
+\t}                                       \n\
+default:                                  \n\
+\tres += 1;                               \n\
+\tthrow ExcClass();                       \n\
+}                                         \n\
+return res; }");
+}


### PR DESCRIPTION
The MissingBreakStatement rule does not handle throw accordingly, if there are multiple commands, before exiting with throw/return with a new created object.

Example of incorrect behaviour can be seen in case 3 and 4 of the appended test.

I am quite sure, that more deeply chained, but correct switch break statements, are still handled incorrectly, such as throw/return within loops and try/catch clauses. But I have not tested such code yet.