### PR TITLE
Fix segfault on methods without CompoundStmt

### DIFF
--- a/oclint-rules/rules/size/LongMethodRule.cpp
+++ b/oclint-rules/rules/size/LongMethodRule.cpp
@@ -16,8 +16,8 @@ private:
         if (decl->hasBody() &&
             !isCppMethodDeclLocatedInCppRecordDecl(dyn_cast<CXXMethodDecl>(decl)))
         {
-            CompoundStmt *compoundStmt = dyn_cast<CompoundStmt>(decl->getBody());
-            int length = getLineCount(compoundStmt->getSourceRange(), _carrier->getSourceManager());
+            Stmt *stmt = decl->getBody();
+            int length = getLineCount(stmt->getSourceRange(), _carrier->getSourceManager());
             int threshold = RuleConfiguration::intForKey("LONG_METHOD", 50);
             if (length > threshold)
             {

--- a/oclint-rules/test/size/LongMethodRuleTest.cpp
+++ b/oclint-rules/test/size/LongMethodRuleTest.cpp
@@ -29,6 +29,12 @@ TEST_F(LongMethodRuleTest, OneLine)
         0, 1, 1, 1, 18, "Method with 1 lines exceeds limit of 0");
 }
 
+TEST_F(LongMethodRuleTest, OneLineWithoutBraces)
+{
+    testRuleOnCXXCode(new LongMethodRule(), "void aMethod() try{} catch(...) {}",
+        0, 1, 1, 1, 34, "Method with 1 lines exceeds limit of 0");
+}
+
 TEST_F(LongMethodRuleTest, TweLines)
 {
     testRuleOnCode(new LongMethodRule(), "void aMethod() {\n}",


### PR DESCRIPTION
It is legal in c++ to leave out the curly braces of function and just
have a single statement like a try-catch or a while loop as the function
body. If we encounter such a method in applyDecl, the dyn_cast will fail
because it is not a CompoundStmt and we get a segfault on a nullptr.

Thankfully, the parent class Stmt also has the getSourceRange() method
that works just as expected from what I have tested so far.

Fixes #467 