### PR TITLE
Fix out of bounds write in XMLReporter

### DIFF
--- a/oclint-reporters/reporters/XMLReporter.cpp
+++ b/oclint-reporters/reporters/XMLReporter.cpp
@@ -48,7 +48,7 @@ public:
     {
         time_t now = time(nullptr);
         struct tm *tmNow = gmtime(&now);
-        char charNow[20];
+        char charNow[21];
         sprintf(charNow,
             "%04i-%02i-%02iT%02i:%02i:%02iZ",
             tmNow->tm_year + 1900,


### PR DESCRIPTION
The string in sprintf is exactly 21 characters long. 20 for the string
itself and then an additional null byte. This did not fit in the given
array.

Fixes #473