### PR TITLE
bundle: fix cpp header install dir

### DIFF
--- a/oclint-scripts/bundle
+++ b/oclint-scripts/bundle
@@ -92,7 +92,7 @@ def install_xcodebuild():
 
 def install_cpp_headers():
     if environment.is_darwin():
-        install_dir = path.build.clang_install_dir
+        install_dir = (path.build.clang_install_dir if not args.llvm_root else args.llvm_root)
         clang_cpp_headers_dir = os.path.join(install_dir, 'include', 'c++')
         oclint_cpp_headers_dir = os.path.join(bundle_include_dir, 'c++')
         path.mkdir_p(bundle_include_dir)
@@ -141,4 +141,3 @@ if not args.docgen:
 
 if args.archive:
     archive(args.release)
-


### PR DESCRIPTION
If the llvm-root option is passed to bundle, the script attempts to
copy the cpp headers from an incorrect location (namely, where oclint
would build them itself).

This commit corrects the path to the cpp headers if the llvm-root
option is passed to bundle so that bundle copies the required headers
from the correct location within the existing LLVM install prefixed by
args.llvm_root.