### PR TITLE
Fixed a bug that does not work properly if the project path contains …

### DIFF
--- a/oclint-driver/lib/Driver.cpp
+++ b/oclint-driver/lib/Driver.cpp
@@ -254,17 +254,17 @@ static std::vector<std::string> adjustArguments(std::vector<std::string> &unadju
     return argAdjuster(unadjustedCmdLine, filename);
 }
 
-std::string Replace(std::string String1, std::string String2, std::string String3)
+std::string stringReplace(std::string orig, std::string from, std::string to)
 {
-    std::string::size_type Pos(String1.find(String2));
+    std::string::size_type pos(orig.find(from));
 
-    while ( Pos != std::string::npos )
+    while ( pos != std::string::npos )
     {
-        String1.replace(Pos, String2.length(), String3);
-        Pos = String1.find(String2, Pos + String3.length());
+        orig.replace(pos, from.length(), to);
+        pos = orig.find(from, pos + to.length());
     }
 
-    return String1;
+    return orig;
 }
 
 static void constructCompilersAndFileManagers(std::vector<oclint::CompilerInstance *> &compilers,
@@ -283,7 +283,7 @@ static void constructCompilersAndFileManagers(std::vector<oclint::CompilerInstan
 
         LOG_VERBOSE("Compiling ");
         LOG_VERBOSE(compileCommand.first.c_str());
-	std::string targetDir = Replace(compileCommand.second.Directory, "\\ ", " ");
+	std::string targetDir = stringReplace(compileCommand.second.Directory, "\\ ", " ");
 
         if(chdir(targetDir.c_str()))
         {
@@ -319,7 +319,7 @@ static void invokeClangStaticAnalyzer(
     {
         LOG_VERBOSE("Clang Static Analyzer ");
         LOG_VERBOSE(compileCommand.first.c_str());
-        std::string targetDir = Replace(compileCommand.second.Directory, "\\ ", " ");
+        std::string targetDir = stringReplace(compileCommand.second.Directory, "\\ ", " ");
         if (chdir(targetDir.c_str()))
         {
             throw oclint::GenericException("Cannot change dictionary into \"" +

--- a/oclint-driver/lib/Driver.cpp
+++ b/oclint-driver/lib/Driver.cpp
@@ -254,6 +254,19 @@ static std::vector<std::string> adjustArguments(std::vector<std::string> &unadju
     return argAdjuster(unadjustedCmdLine, filename);
 }
 
+std::string Replace(std::string String1, std::string String2, std::string String3)
+{
+    std::string::size_type Pos(String1.find(String2));
+
+    while ( Pos != std::string::npos )
+    {
+        String1.replace(Pos, String2.length(), String3);
+        Pos = String1.find(String2, Pos + String3.length());
+    }
+
+    return String1;
+}
+
 static void constructCompilersAndFileManagers(std::vector<oclint::CompilerInstance *> &compilers,
     std::vector<clang::FileManager *> &fileManagers,
     CompileCommandPairs &compileCommands,
@@ -270,10 +283,12 @@ static void constructCompilersAndFileManagers(std::vector<oclint::CompilerInstan
 
         LOG_VERBOSE("Compiling ");
         LOG_VERBOSE(compileCommand.first.c_str());
-        if (chdir(compileCommand.second.Directory.c_str()))
+	std::string targetDir = Replace(compileCommand.second.Directory, "\\ ", " ");
+
+        if(chdir(targetDir.c_str()))
         {
             throw oclint::GenericException("Cannot change dictionary into \"" +
-                compileCommand.second.Directory + "\", "
+                targetDir + "\", "
                 "please make sure the directory exists and you have permission to access!");
         }
         clang::CompilerInvocation *compilerInvocation =
@@ -304,10 +319,11 @@ static void invokeClangStaticAnalyzer(
     {
         LOG_VERBOSE("Clang Static Analyzer ");
         LOG_VERBOSE(compileCommand.first.c_str());
-        if (chdir(compileCommand.second.Directory.c_str()))
+        std::string targetDir = Replace(compileCommand.second.Directory, "\\ ", " ");
+        if (chdir(targetDir.c_str()))
         {
             throw oclint::GenericException("Cannot change dictionary into \"" +
-                compileCommand.second.Directory + "\", "
+                targetDir + "\", "
                 "please make sure the directory exists and you have permission to access!");
         }
         std::vector<std::string> adjustedArguments =


### PR DESCRIPTION
…spaces.

If the path of the project to be analyzed by OCLint includes spaces as shown in the following example, an error occurs in the existence confirmation of the target path and it is not processed normally.

Project path like:
/Users/me/My Project/MyApp/Someware

For example, in compile_commands.json created with the option -r json-compilation-database in the xcpretty command, the space contained in the path is escaped with a backslash like this, but oclint-json-compilation-database do not care about this.

JSON contained like this:
“/Users/me/My\\ Project/MyApp/Someware”

Likewise, in the path of the compile command returned by clang::tooling::CompileCommand in oclint-driver/lib/Driver.cpp, escape with backslash well if the path contains spaces. It also needed a fix.