### PR TITLE
Build multiple reports at once

### DIFF
--- a/oclint-driver/reporters.h
+++ b/oclint-driver/reporters.h
@@ -3,4 +3,4 @@
 #include "oclint/Reporter.h"
 
 void loadReporter();
-oclint::Reporter* reporter();
+std::vector<oclint::Reporter*> reporter();

--- a/oclint-driver/reporters_dlfcn_port.cpp
+++ b/oclint-driver/reporters_dlfcn_port.cpp
@@ -1,17 +1,36 @@
 #include <dirent.h>
 #include <dlfcn.h>
 #include <iostream>
+#include <string>
+#include <sstream>
+#include <algorithm>
+#include <iterator>
+#include <unordered_set>
 
 #include "oclint/GenericException.h"
 #include "oclint/Options.h"
+#include "llvm/ADT/StringRef.h"
 
 #include "reporters.h"
 
-static oclint::Reporter* selectedReporter = nullptr;
+static std::vector<oclint::Reporter*> selectedReporterVector;
 
 void loadReporter()
 {
-    selectedReporter = nullptr;
+    selectedReporterVector.clear();
+
+    // Create a set that contains all the report types
+    std::unordered_set<std::string> reportTypeSet;
+    std::stringstream ss(oclint::option::reportType());
+    
+    while(ss.good())
+    {
+        std::string reportType;
+        std::getline(ss, reportType, ',');
+        reportTypeSet.insert(reportType);
+    }
+
+    // Load the specified reporters
     std::string reportDirPath = oclint::option::reporterPath();
     DIR *pDir = opendir(reportDirPath.c_str());
     if (pDir != nullptr)
@@ -34,22 +53,21 @@ void loadReporter()
             oclint::Reporter* (*createMethodPointer)();
             createMethodPointer = (oclint::Reporter* (*)())dlsym(reporterHandle, "create");
             oclint::Reporter* reporter = (oclint::Reporter*)createMethodPointer();
-            if (reporter->name() == oclint::option::reportType())
+            if(reportTypeSet.find(reporter->name()) != reportTypeSet.end())
             {
-                selectedReporter = reporter;
-                break;
+                selectedReporterVector.push_back(reporter);
             }
         }
         closedir(pDir);
     }
-    if (selectedReporter == nullptr)
+    if (selectedReporterVector.size() == 0)
     {
         throw oclint::GenericException(
             "cannot find dynamic library for report type: " + oclint::option::reportType());
     }
 }
 
-oclint::Reporter* reporter()
+std::vector<oclint::Reporter*> reporter()
 {
-    return selectedReporter;
+    return selectedReporterVector;
 }


### PR DESCRIPTION
Enable OCLint to generate different reports at once.

For example, If the argument is like that `-report-type html,json,xml -o test/reporter.*`, then `reporter.html, reporter.json, reporter.xml` will be generated in `test` folder.
