### PR TITLE
ASTVisitorRule can choose to lint header files or not

### DIFF
--- a/oclint-rules/include/oclint/AbstractASTVisitorRule.h
+++ b/oclint-rules/include/oclint/AbstractASTVisitorRule.h
@@ -2,7 +2,6 @@
 #define OCLINT_ABSTRACTASTVISITORRULE_H
 
 #include <clang/AST/RecursiveASTVisitor.h>
-
 #include "oclint/AbstractASTRuleBase.h"
 
 namespace oclint
@@ -12,7 +11,41 @@ template<typename T>
 class AbstractASTVisitorRule : public AbstractASTRuleBase, protected clang::RecursiveASTVisitor<T>
 {
     friend class clang::RecursiveASTVisitor<T>;
+private:
+    virtual bool shouldTraverseFile(clang::SourceLocation startLocation)
+    {
+        clang::SourceManager *sourceManager = &_carrier->getSourceManager();
+
+        if (sourceManager->getMainFileID() == sourceManager->getFileID(startLocation))
+        {
+            return true;
+        }
+
+        if (!visitHeaders())
+        {
+            return false;
+        }
+
+        llvm::StringRef sourceFileName = sourceManager->getFilename(startLocation);
+        return isAnalyzeFileHeadFile(sourceFileName);
+    }
+
+    virtual bool isAnalyzeFileHeadFile(llvm::StringRef fileNameStrRef) {
+        return true;
+        if (fileNameStrRef.empty())
+            return false;
+
+        std::string currentAnalyzeFilePath = _carrier->getMainFilePath().c_str();
+        std::string subString = currentAnalyzeFilePath.erase(currentAnalyzeFilePath.length() - 1);
+        return fileNameStrRef.str().find(subString) == 0;
+    }
+
 protected:
+    virtual bool visitHeaders()
+    {
+        return false;
+    }
+
     virtual void apply()
     {
         if (!isLanguageSupported())
@@ -21,17 +54,14 @@ protected:
         }
 
         setUp();
-        clang::SourceManager *sourceManager = &_carrier->getSourceManager();
         clang::DeclContext *decl = _carrier->getTranslationUnitDecl();
         for (clang::DeclContext::decl_iterator it = decl->decls_begin(), declEnd = decl->decls_end();
             it != declEnd; ++it)
         {
             clang::SourceLocation startLocation = (*it)->getLocStart();
-            if (startLocation.isValid() &&
-                sourceManager->getMainFileID() == sourceManager->getFileID(startLocation))
-            {
+            if(shouldTraverseFile(startLocation)){
                 (void) /* explicitly ignore the return of this function */
-                    clang::RecursiveASTVisitor<T>::TraverseDecl(*it);
+                clang::RecursiveASTVisitor<T>::TraverseDecl(*it);
             }
         }
         tearDown();

--- a/oclint-rules/include/oclint/AbstractASTVisitorRule.h
+++ b/oclint-rules/include/oclint/AbstractASTVisitorRule.h
@@ -14,13 +14,20 @@ class AbstractASTVisitorRule : public AbstractASTRuleBase, protected clang::Recu
 private:
     virtual bool shouldTraverseFile(clang::SourceLocation startLocation)
     {
+        if(startLocation.isInvalid())
+        {
+            return false;
+        }
+
         clang::SourceManager *sourceManager = &_carrier->getSourceManager();
 
+        /* If the decl is in the current file, traverse it */
         if (sourceManager->getMainFileID() == sourceManager->getFileID(startLocation))
         {
             return true;
         }
 
+        /* If the user want to lint header files and decl is in the associated header file, traverse it */
         if (!visitHeaders())
         {
             return false;
@@ -30,10 +37,12 @@ private:
         return isAnalyzeFileHeadFile(sourceFileName);
     }
 
+    /* Check if decl is in the associated header file */
     virtual bool isAnalyzeFileHeadFile(llvm::StringRef fileNameStrRef) {
-        return true;
         if (fileNameStrRef.empty())
+        {
             return false;
+        }
 
         std::string currentAnalyzeFilePath = _carrier->getMainFilePath().c_str();
         std::string subString = currentAnalyzeFilePath.erase(currentAnalyzeFilePath.length() - 1);


### PR DESCRIPTION
Inspired by this issue: https://github.com/oclint/oclint/issues/450. 
By default the ASTVisitor rule will only lint source files. But if it overrides the `visitHeaders()`, it will anaylize the header files which have the correspoinding source files. For example, `abc.h` will be lint if there is a `abc.m` file.
```cpp
virtual bool visitHeaders() override
    {
        return true;
    }
```