### PR TITLE
Add a utility function for ASTRule

### DIFF
--- a/oclint-rules/include/oclint/AbstractASTRuleBase.h
+++ b/oclint-rules/include/oclint/AbstractASTRuleBase.h
@@ -3,6 +3,7 @@
 
 #include <clang/AST/AST.h>
 
+#include "clang/Lex/Lexer.h"
 #include "oclint/RuleBase.h"
 
 namespace oclint
@@ -23,6 +24,7 @@ protected:
 
     void addViolation(const clang::Decl *decl, RuleBase *rule, const std::string& message = "");
     void addViolation(const clang::Stmt *stmt, RuleBase *rule, const std::string& message = "");
+    std::string declToStr(clang::Decl *decl);
 
 private:
     bool supportsC() const;

--- a/oclint-rules/lib/AbstractASTRuleBase.cpp
+++ b/oclint-rules/lib/AbstractASTRuleBase.cpp
@@ -37,6 +37,18 @@ void AbstractASTRuleBase::addViolation(const clang::Decl *decl,
     }
 }
 
+/* Given a clang declaration, find its associated source code */
+std::string AbstractASTRuleBase::declToStr(clang::Decl *decl)
+{
+    clang::SourceManager *sourceManager = &_carrier->getSourceManager();
+    clang::LangOptions langOptions;
+
+    clang::SourceLocation begin(decl->getLocStart()), _end(decl->getLocEnd());
+    clang::SourceLocation end(clang::Lexer::getLocForEndOfToken(_end, 0, *sourceManager, langOptions));
+    return std::string(sourceManager->getCharacterData(begin),
+                  sourceManager->getCharacterData(end)-sourceManager->getCharacterData(begin));
+}
+
 void AbstractASTRuleBase::addViolation(const clang::Stmt *stmt,
     RuleBase *rule, const std::string& message)
 {


### PR DESCRIPTION
When writing new custom rules, finding out that a utility function that gets the source codes of a `clang::Decl` is useful.