### PR TITLE
Update build scripts to Python 3

### DIFF
--- a/oclint-driver/lib/ConfigFile.cpp
+++ b/oclint-driver/lib/ConfigFile.cpp
@@ -176,6 +176,7 @@ static llvm::Optional<bool> createOptionalBool(const TriState value)
     case TRUE:
         return llvm::Optional<bool>(true);
     case UNDEFINED:
+    default:
         return llvm::Optional<bool>();
     }
 }

--- a/oclint-reporters/reporters/XMLReporter.cpp
+++ b/oclint-reporters/reporters/XMLReporter.cpp
@@ -48,7 +48,7 @@ public:
     {
         time_t now = time(nullptr);
         struct tm *tmNow = gmtime(&now);
-        char charNow[21];
+        char charNow[28];
         sprintf(charNow,
             "%04i-%02i-%02iT%02i:%02i:%02iZ",
             tmNow->tm_year + 1900,

--- a/oclint-scripts/build
+++ b/oclint-scripts/build
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import shutil

--- a/oclint-scripts/bundle
+++ b/oclint-scripts/bundle
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import shutil

--- a/oclint-scripts/ci
+++ b/oclint-scripts/ci
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import shutil
@@ -20,7 +20,7 @@ arg_parser.add_argument('-j', type=int, default=0)
 args = arg_parser.parse_args()
 
 def upload_snapshot():
-    process.call('python upload')
+    process.call('python3 upload')
 
 if args.reset:
     path.rm_f(path.build_root)
@@ -37,21 +37,21 @@ if args.setup:
     if environment.is_darwin():
         process.call('git clone ' + path.url.xcodebuild)
     path.cd(current_dir)
-    process.call('python clang')
+    process.call('python3 clang')
     if not args.release:
-        process.call('python googleTest co')
-        process.call('python googleTest build -clean' + process.j_flag(args.j))
+        process.call('python3 googleTest co')
+        process.call('python3 googleTest build -clean' + process.j_flag(args.j))
 
 if args.release:
-    process.call('python build -clean -release' + process.j_flag(args.j))
+    process.call('python3 build -clean -release' + process.j_flag(args.j))
 else:
-    process.call('python test -clean' + process.j_flag(args.j))
-    process.call('python build -clean' + process.j_flag(args.j))
-process.call('python bundle')
+    process.call('python3 test -clean' + process.j_flag(args.j))
+    process.call('python3 build -clean' + process.j_flag(args.j))
+process.call('python3 bundle')
 if environment.is_unix() and not args.release:
-    process.call('python dogFooding -enable-clang-static-analyzer')
+    process.call('python3 dogFooding -enable-clang-static-analyzer')
 if args.archive:
     if args.release:
-        process.call('python bundle -archive -release')
+        process.call('python3 bundle -archive -release')
     else:
-        process.call('python bundle -archive')
+        process.call('python3 bundle -archive')

--- a/oclint-scripts/clang
+++ b/oclint-scripts/clang
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import os

--- a/oclint-scripts/dogFooding
+++ b/oclint-scripts/dogFooding
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import shutil

--- a/oclint-scripts/googleTest
+++ b/oclint-scripts/googleTest
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import shutil

--- a/oclint-scripts/oclintscripts/cmake.py
+++ b/oclint-scripts/oclintscripts/cmake.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import os
 

--- a/oclint-scripts/oclintscripts/environment.py
+++ b/oclint-scripts/oclintscripts/environment.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import platform
 import multiprocessing

--- a/oclint-scripts/oclintscripts/path.py
+++ b/oclint-scripts/oclintscripts/path.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import os
 import shutil

--- a/oclint-scripts/oclintscripts/process.py
+++ b/oclint-scripts/oclintscripts/process.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import subprocess
 import sys
@@ -14,7 +14,7 @@ def j_flag(j=None):
     multiple_thread = environment.cpu_count()
     if environment.is_mingw32():
         multiple_thread = 1
-    if j is not None and j is not 0:
+    if j != None and j != 0:
         multiple_thread = j
     return ' -j ' + str(multiple_thread)
 
@@ -22,7 +22,7 @@ def make(j=None):
     call('make' + j_flag(j))
 
 def ninja(j=None):
-    if j is not None and j is not 0:
+    if j != None and j != 0:
         call('ninja' + j_flag(j))
     else:
         call('ninja')

--- a/oclint-scripts/oclintscripts/version.py
+++ b/oclint-scripts/oclintscripts/version.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import subprocess
 import os
@@ -10,7 +10,7 @@ def dev_version():
     current_working_folder = os.getcwd()
     try:
         os.chdir(path.root_dir)
-        git_hash = subprocess.check_output(['git', 'log', '-n', '1', '--pretty=%h']).split()[0]
+        git_hash = subprocess.check_output(['git', 'log', '-n', '1', '--pretty=%h'], encoding='utf8').split()[0]
         path.cd(current_working_folder)
         return git_hash
     except:

--- a/oclint-scripts/scaffoldReporter
+++ b/oclint-scripts/scaffoldReporter
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import os
 import re

--- a/oclint-scripts/scaffoldRule
+++ b/oclint-scripts/scaffoldRule
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import os
 import re

--- a/oclint-scripts/test
+++ b/oclint-scripts/test
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import shutil

--- a/oclint-scripts/upload
+++ b/oclint-scripts/upload
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import json
 import sys


### PR DESCRIPTION
Since Python 2 has reached its end-of-life, and Linux distros such as Ubuntu 20.04 no longer ship with Python 2, upgrading to Python 3 seems like the right move.

This branch also fixes a couple of compiler warnings from GCC 9.3.0.