### PR TITLE
Small improvements in Python scripts

### DIFF
--- a/oclint-scripts/build
+++ b/oclint-scripts/build
@@ -1,13 +1,9 @@
 #! /usr/bin/env python3
 
 import argparse
-import shutil
-import subprocess
-import sys
 import os
 
 from oclintscripts import cmake
-from oclintscripts import environment
 from oclintscripts import path
 from oclintscripts import process
 

--- a/oclint-scripts/ci
+++ b/oclint-scripts/ci
@@ -1,15 +1,12 @@
 #! /usr/bin/env python3
 
 import argparse
-import shutil
-import subprocess
 import sys
 import os
 
 from oclintscripts import environment
 from oclintscripts import path
 from oclintscripts import process
-from oclintscripts import version
 
 arg_parser = argparse.ArgumentParser()
 arg_parser.add_argument('-reset', '--reset', action="store_true")
@@ -20,7 +17,7 @@ arg_parser.add_argument('-j', type=int, default=0)
 args = arg_parser.parse_args()
 
 def upload_snapshot():
-    process.call('python3 upload')
+    process.call(f'{sys.executable} upload')
 
 if args.reset:
     path.rm_f(path.build_root)
@@ -37,21 +34,21 @@ if args.setup:
     if environment.is_darwin():
         process.call('git clone ' + path.url.xcodebuild)
     path.cd(current_dir)
-    process.call('python3 clang')
+    process.call(f'{sys.executable} clang')
     if not args.release:
-        process.call('python3 googleTest co')
-        process.call('python3 googleTest build -clean' + process.j_flag(args.j))
+        process.call(f'{sys.executable} googleTest co')
+        process.call(f'{sys.executable} googleTest build -clean' + process.j_flag(args.j))
 
 if args.release:
-    process.call('python3 build -clean -release' + process.j_flag(args.j))
+    process.call(f'{sys.executable} build -clean -release' + process.j_flag(args.j))
 else:
-    process.call('python3 test -clean' + process.j_flag(args.j))
-    process.call('python3 build -clean' + process.j_flag(args.j))
-process.call('python3 bundle')
+    process.call(f'{sys.executable} test -clean' + process.j_flag(args.j))
+    process.call(f'{sys.executable} build -clean' + process.j_flag(args.j))
+process.call(f'{sys.executable} bundle')
 if environment.is_unix() and not args.release:
-    process.call('python3 dogFooding -enable-clang-static-analyzer')
+    process.call(f'{sys.executable} dogFooding -enable-clang-static-analyzer')
 if args.archive:
     if args.release:
-        process.call('python3 bundle -archive -release')
+        process.call(f'{sys.executable} bundle -archive -release')
     else:
-        process.call('python3 bundle -archive')
+        process.call(f'{sys.executable} bundle -archive')

--- a/oclint-scripts/oclintscripts/environment.py
+++ b/oclint-scripts/oclintscripts/environment.py
@@ -2,7 +2,6 @@
 
 import platform
 import multiprocessing
-import subprocess
 
 def cpu_count():
     return multiprocessing.cpu_count()

--- a/oclint-scripts/oclintscripts/version.py
+++ b/oclint-scripts/oclintscripts/version.py
@@ -4,7 +4,6 @@ import subprocess
 import os
 
 from oclintscripts import path
-from oclintscripts import environment
 
 def dev_version():
     current_working_folder = os.getcwd()


### PR DESCRIPTION
Remove unused imports
Calling python using `sys.executable` instead of just python/python3