### PR TITLE
Add support for building code locally on Ubuntu 18.04 LTS

### DIFF
--- a/oclint-scripts/clang
+++ b/oclint-scripts/clang
@@ -30,7 +30,10 @@ def setup_prebuilt_binary():
         if environment.is_aarch64_or_arm64():
             binary_url = path.url.clang_prebuilt_binary_for_ubuntu_lts_20_aarch64
         else:
-            binary_url = path.url.clang_prebuilt_binary_for_ubuntu_lts_20
+            if environment.is_ubuntu_18():
+                binary_url = path.url.clang_prebuilt_binary_for_ubuntu_lts_18
+            else:
+                binary_url = path.url.clang_prebuilt_binary_for_ubuntu_lts_20
 
     current_dir = os.getcwd()
     path.mkdir_p(build_path)

--- a/oclint-scripts/oclintscripts/environment.py
+++ b/oclint-scripts/oclintscripts/environment.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 
+import distro
 import platform
 import multiprocessing
 
@@ -16,7 +17,7 @@ def arch():
     return platform.uname()[4].lower()
 
 def linux_distribution():
-    return platform.linux_distribution()
+    return distro.linux_distribution()
 
 def dist_env():
     return arch() + '-' + kernel() + '-' + kernel_version()

--- a/oclint-scripts/oclintscripts/environment.py
+++ b/oclint-scripts/oclintscripts/environment.py
@@ -34,5 +34,8 @@ def is_darwin():
 def is_linux():
     return kernel().startswith("linux")
 
+def is_ubuntu_18():
+    return linux_distribution()[0] == 'Ubuntu' and linux_distribution()[1] == '18.04'
+
 def is_unix():
     return is_darwin() or is_linux()

--- a/oclint-scripts/oclintscripts/path.py
+++ b/oclint-scripts/oclintscripts/path.py
@@ -71,6 +71,7 @@ class url:
 
     clang_prebuilt_binary_for_macos = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-apple-darwin.tar.xz'
     clang_prebuilt_binary_for_macos_arm64 = 'https://github.com/ryuichis/llvm-builder/releases/download/llvm-13.0.1/llvm-13.0.1-arm64-apple-darwin.tar.xz'
+    clang_prebuilt_binary_for_ubuntu_lts_18 = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
     clang_prebuilt_binary_for_ubuntu_lts_20 = 'https://github.com/ryuichis/llvm-builder/releases/download/llvm-13.0.1/llvm-13.0.1-x86_64-linux-gnu-ubuntu-20.04.tar.xz'
     clang_prebuilt_binary_for_ubuntu_lts_20_aarch64 = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-aarch64-linux-gnu.tar.xz'
 


### PR DESCRIPTION
This pull request fixes issue #634 by using the prebuilt clang+llvm [binary](https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz) for ubuntu 18.04 LTS, if the code is built inside ubuntu 18.04.

The user will have to install the [distro](https://pypi.org/project/distro/) python package. The distro package replaces the [deprecated](https://github.com/python/cpython/issues/45663) `platform.linux_distribution()` method.